### PR TITLE
Role: Coder-R150: close TiFlash donor runtime evidence gap for tiforth#250

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -22,6 +22,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <fmt/core.h>
+#include <iostream>
 #include <optional>
 #include <string>
 #include <vector>
@@ -34,9 +35,7 @@ namespace
 constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
 constexpr uint32_t PLAN_KIND_CAST_UTF8_TO_DECIMAL = 1;
 constexpr uint32_t INPUT_ID_SCALAR = 0;
-constexpr uint32_t SQL_MODE_DEFAULT = 1;
-constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
-constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
+constexpr uint32_t SQL_MODE_TRUNCATE_AS_WARNING = 2;
 constexpr uint32_t STATUS_KIND_OK = 0;
 constexpr uint32_t STATUS_KIND_PROTOCOL_ERROR = 5;
 constexpr uint32_t STATUS_CODE_NONE = 0;
@@ -236,6 +235,12 @@ std::optional<String> resolveExecutionHostV2LibraryPath()
     return std::nullopt;
 }
 
+bool requiresStrictRuntimeExecution()
+{
+    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
+    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
+}
+
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
 {
     if (column.null_bitmap == nullptr || row_count == 0)
@@ -346,6 +351,21 @@ struct AdapterRunResult
     uint32_t warning_count = 0;
 };
 
+class ScopedDAGFlags
+{
+public:
+    explicit ScopedDAGFlags(DAGContext & dag_context_)
+        : dag_context(dag_context_)
+        , original_flags(dag_context_.getFlags())
+    {}
+
+    ~ScopedDAGFlags() { dag_context.setFlags(original_flags); }
+
+private:
+    DAGContext & dag_context;
+    UInt64 original_flags;
+};
+
 class TestTiforthExecutionHostV2Cast : public FunctionTest
 {
 public:
@@ -372,14 +392,14 @@ public:
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
         build_request.plan_kind = PLAN_KIND_CAST_UTF8_TO_DECIMAL;
         build_request.ambient_requirement_mask = AMBIENT_REQUIREMENT_SQL_MODE;
-        build_request.sql_mode = SQL_MODE_DEFAULT;
-        build_request.session_charset = SESSION_CHARSET_UTF8MB4;
-        build_request.default_collation = DEFAULT_COLLATION_UTF8MB4_BIN;
+        build_request.sql_mode = SQL_MODE_TRUNCATE_AS_WARNING;
+        build_request.session_charset = 0;
+        build_request.default_collation = 0;
         build_request.decimal_precision_is_set = true;
         build_request.decimal_precision = 10;
         build_request.decimal_scale_is_set = true;
         build_request.decimal_scale = 3;
-        build_request.max_block_size = 256;
+        build_request.max_block_size = 0;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -480,10 +500,15 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
     auto maybe_library = resolveExecutionHostV2LibraryPath();
     if (!maybe_library.has_value())
     {
-        SUCCEED() << "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
         return;
     }
 
@@ -491,11 +516,16 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
     if (!maybe_api.has_value())
     {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
         SUCCEED() << load_error;
         return;
     }
 
     auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
 
     const std::vector<std::optional<String>> input = {
         String("12.345"),
@@ -507,7 +537,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     };
 
     auto donor_native = runDonorNativeCastAsString(input);
-    const auto donor_warning_count = getDAGContext().getWarningCount();
+    const auto donor_warning_count = dag_context.getWarningCount();
 
     AdapterRunResult serial;
     runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
@@ -519,14 +549,23 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 
     ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
     ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast] serial=1 warnings=" << serial.warning_count << " rows=" << serial.output.size()
+              << " parallel=2 warnings=" << parallel.warning_count << " rows=" << parallel.output.size()
+              << " donor_warnings=" << donor_warning_count << " parity=ok" << std::endl;
 }
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
     auto maybe_library = resolveExecutionHostV2LibraryPath();
     if (!maybe_library.has_value())
     {
-        SUCCEED() << "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
         return;
     }
 
@@ -534,11 +573,16 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
     auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
     if (!maybe_api.has_value())
     {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
         SUCCEED() << load_error;
         return;
     }
 
     auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
 
     const std::vector<std::optional<String>> input = {
         String("1.2395"),
@@ -549,7 +593,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
     };
 
     auto donor_native = runDonorNativeCastAsString(input);
-    const auto donor_warning_count = static_cast<uint32_t>(getDAGContext().getWarningCount());
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_GT(donor_warning_count, 0u);
 
     AdapterRunResult serial;
@@ -562,6 +606,11 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
     ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
     ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast-scale-loss] serial=1 warnings=" << serial.warning_count
+              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
+              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
+              << std::endl;
 }
 
 } // namespace

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -25,6 +25,7 @@
 #include <dlfcn.h>
 #include <filesystem>
 #include <fmt/core.h>
+#include <iostream>
 #include <optional>
 #include <string>
 #include <utility>
@@ -122,6 +123,11 @@ struct TiforthExecutionHostV2Api
         TiforthStatusV2 *,
         TiforthBatchViewV2 *);
     using DriveEndOfInputFn = void (*) (TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
+    using DriveEndOfInputWithOutputFn = void (*) (
+        TiforthExecutionInstanceHandleV2 *,
+        uint32_t,
+        TiforthStatusV2 *,
+        TiforthBatchViewV2 *);
     using ContinueOutputFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
     using FinishFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
     using ReleaseExecutableFn = void (*) (TiforthExecutionExecutableHandleV2 *);
@@ -132,6 +138,7 @@ struct TiforthExecutionHostV2Api
     OpenFn open = nullptr;
     DriveInputBatchFn drive_input_batch = nullptr;
     DriveEndOfInputFn drive_end_of_input = nullptr;
+    DriveEndOfInputWithOutputFn drive_end_of_input_with_output = nullptr;
     ContinueOutputFn continue_output = nullptr;
     FinishFn finish = nullptr;
     ReleaseExecutableFn release_executable = nullptr;
@@ -153,6 +160,7 @@ struct TiforthExecutionHostV2Api
         open = other.open;
         drive_input_batch = other.drive_input_batch;
         drive_end_of_input = other.drive_end_of_input;
+        drive_end_of_input_with_output = other.drive_end_of_input_with_output;
         continue_output = other.continue_output;
         finish = other.finish;
         release_executable = other.release_executable;
@@ -163,6 +171,7 @@ struct TiforthExecutionHostV2Api
         other.open = nullptr;
         other.drive_input_batch = nullptr;
         other.drive_end_of_input = nullptr;
+        other.drive_end_of_input_with_output = nullptr;
         other.continue_output = nullptr;
         other.finish = nullptr;
         other.release_executable = nullptr;
@@ -217,6 +226,11 @@ std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(const String & l
         || !loadSymbol(handle, "tiforth_execution_host_v2_open", api.open, error)
         || !loadSymbol(handle, "tiforth_execution_host_v2_drive_input_batch", api.drive_input_batch, error)
         || !loadSymbol(handle, "tiforth_execution_host_v2_drive_end_of_input", api.drive_end_of_input, error)
+        || !loadSymbol(
+            handle,
+            "tiforth_execution_host_v2_drive_end_of_input_with_output",
+            api.drive_end_of_input_with_output,
+            error)
         || !loadSymbol(handle, "tiforth_execution_host_v2_continue_output", api.continue_output, error)
         || !loadSymbol(handle, "tiforth_execution_host_v2_finish", api.finish, error)
         || !loadSymbol(handle, "tiforth_execution_host_v2_release_executable", api.release_executable, error)
@@ -238,6 +252,12 @@ std::optional<String> resolveExecutionHostV2LibraryPath()
     }
 
     return std::nullopt;
+}
+
+bool requiresStrictRuntimeExecution()
+{
+    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
+    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
 }
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
@@ -635,7 +655,7 @@ public:
         build_request.decimal_precision = 0;
         build_request.decimal_scale_is_set = false;
         build_request.decimal_scale = 0;
-        build_request.max_block_size = 1;
+        build_request.max_block_size = 0;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -720,14 +740,22 @@ public:
 
         drive_input_rows(build_rows, INPUT_ID_BUILD);
 
-        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        TiforthBatchViewV2 build_end_output{};
+        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(build_end_output, result.rows);
         drain_output();
 
         drive_input_rows(probe_rows, INPUT_ID_PROBE);
 
-        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        TiforthBatchViewV2 probe_end_output{};
+        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
         api.finish(instance, &status);
@@ -757,7 +785,7 @@ public:
         build_request.decimal_precision = 0;
         build_request.decimal_scale_is_set = false;
         build_request.decimal_scale = 0;
-        build_request.max_block_size = 1;
+        build_request.max_block_size = 0;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -840,14 +868,22 @@ public:
 
         drive_input_rows(build_rows, INPUT_ID_BUILD);
 
-        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        TiforthBatchViewV2 build_end_output{};
+        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(build_end_output, result.rows);
         drain_output();
 
         drive_input_rows(probe_rows, INPUT_ID_PROBE);
 
-        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        TiforthBatchViewV2 probe_end_output{};
+        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
         api.finish(instance, &status);
@@ -877,7 +913,7 @@ public:
         build_request.decimal_precision = 0;
         build_request.decimal_scale_is_set = false;
         build_request.decimal_scale = 0;
-        build_request.max_block_size = 1;
+        build_request.max_block_size = 0;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -961,14 +997,22 @@ public:
 
         drive_input_rows(build_rows, INPUT_ID_BUILD);
 
-        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        TiforthBatchViewV2 build_end_output{};
+        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(build_end_output, result.rows);
         drain_output();
 
         drive_input_rows(probe_rows, INPUT_ID_PROBE);
 
-        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        TiforthBatchViewV2 probe_end_output{};
+        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
         api.finish(instance, &status);
@@ -984,10 +1028,15 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
     auto maybe_library = resolveExecutionHostV2LibraryPath();
     if (!maybe_library.has_value())
     {
-        SUCCEED() << "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
         return;
     }
 
@@ -995,6 +1044,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
     auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
     if (!maybe_api.has_value())
     {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
         SUCCEED() << load_error;
         return;
     }
@@ -1017,14 +1068,24 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
 
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-inner-join] serial=1 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
     auto maybe_library = resolveExecutionHostV2LibraryPath();
     if (!maybe_library.has_value())
     {
-        SUCCEED() << "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
         return;
     }
 
@@ -1032,6 +1093,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
     auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
     if (!maybe_api.has_value())
     {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
         SUCCEED() << load_error;
         return;
     }
@@ -1054,14 +1117,24 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
 
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-build-outer-join] serial=1 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
     auto maybe_library = resolveExecutionHostV2LibraryPath();
     if (!maybe_library.has_value())
     {
-        SUCCEED() << "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
         return;
     }
 
@@ -1069,6 +1142,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
     auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
     if (!maybe_api.has_value())
     {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
         SUCCEED() << load_error;
         return;
     }
@@ -1091,6 +1166,11 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
 
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-probe-outer-join] serial=1 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
 } // namespace


### PR DESCRIPTION
Role: Coder-R150

advances: zanmato1984/tiforth#232
Closes zanmato1984/tiforth#250

## Scope
- proving side coverage: function hard CAST + operator bounded inner hash join (including build/probe outer host-v2 adapter parity entrypoints)
- repo/branch: `zanmato1984/tiflash-donor:tiforth` against `master`

## What changed
- enforced strict runtime mode for donor adapter tests via `TIFORTH_REQUIRE_RUNTIME_EXECUTION`; in strict mode, missing dylib/symbol now hard-fails instead of silently succeeding
- aligned host-v2 build request metadata with current tiforth runtime contract:
  - CAST: keep ambient `sql_mode`, drop session charset/default collation payload, set `max_block_size=0`
  - join plans: set `max_block_size=0` and load/use `drive_end_of_input_with_output` for end-of-input paths that emit rows
- added deterministic donor parity stdout markers for serial (`serial=1`) and parallel (`parallel=2`) runs across CAST/inner-join/build-outer/probe-outer tests
- fixed CAST scale-loss parity mode by enabling donor `TRUNCATE_AS_WARNING` flags in test scope and matching adapter sql_mode for warning parity

## Runtime evidence (strict executable run)
Command executed:
```bash
TIFORTH_FFI_C_DYLIB=/Users/zanmato/dev/tiforth-worktrees/tiforth-issue-250-r150-20260407-131641/target/debug/libtiforth_ffi_c.dylib \
TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
./cmake-build-debug/dbms/gtests_dbms \
  --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*' \
  --gtest_color=no
```

Key output lines from this strict run:
- `[tiforth-host-v2-cast] serial=1 warnings=0 rows=6 parallel=2 warnings=0 rows=6 donor_warnings=0 parity=ok`
- `[tiforth-host-v2-cast-scale-loss] serial=1 warnings=4 rows=5 parallel=2 warnings=4 rows=5 donor_warnings=4 parity=ok`
- `[tiforth-host-v2-inner-join] serial=1 warnings=0 rows=3 parallel=2 warnings=0 rows=3 donor_warnings=0 donor_rows=3 parity=ok`
- `[tiforth-host-v2-build-outer-join] serial=1 warnings=0 rows=4 parallel=2 warnings=0 rows=4 donor_warnings=0 donor_rows=4 parity=ok`
- `[tiforth-host-v2-probe-outer-join] serial=1 warnings=0 rows=5 parallel=2 warnings=0 rows=5 donor_warnings=0 donor_rows=5 parity=ok`
- `[  PASSED  ] 5 tests.`

Because strict mode is enabled, this evidence cannot pass through missing `TIFORTH_FFI_C_DYLIB` or missing symbol fallback branches.
