### PR TITLE
Role: Coder-R151: add TiFlash donor host-v2 cast invalid-syntax parity slice

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -613,5 +613,64 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
               << std::endl;
 }
 
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
+{
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    auto maybe_library = resolveExecutionHostV2LibraryPath();
+    if (!maybe_library.has_value())
+    {
+        const String message
+            = "set TIFORTH_FFI_C_DYLIB to a built tiforth ffi/c shared library to run this donor adapter test";
+        if (strict_runtime_execution)
+            GTEST_FAIL() << message;
+        SUCCEED() << message;
+        return;
+    }
+
+    String load_error;
+    auto maybe_api = loadExecutionHostV2Api(maybe_library.value(), load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("bad"),
+        String("1.2.3"),
+        String("12.340"),
+        String("-0.500"),
+        std::nullopt,
+        String(""),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_GT(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast-invalid-syntax] serial=1 warnings=" << serial.warning_count
+              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
+              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
+              << std::endl;
+}
+
 } // namespace
 } // namespace DB::tests


### PR DESCRIPTION
Role: Coder-R151

Closes zanmato1984/tiforth#232
Refs zanmato1984/tiforth#235
Refs zanmato1984/tiforth#250

## Summary
- add a donor-side host-v2 CAST parity slice for invalid numeric syntax under `TRUNCATE_AS_WARNING`
- execute serial (`partitions=1`, borrow-within-call) and parallel (`partitions=2`, foreign-retainable) adapter paths on the same donor input batch
- assert warning-count parity and output parity against donor-native `tidb_cast`

## Validation
- `cmake --preset dev`
- `ninja -C cmake-build-debug dbms/CMakeFiles/gtests_dbms.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp.o`
- `ninja -C cmake-build-debug dbms/CMakeFiles/gtests_dbms.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp.o`
- attempted `ninja -C cmake-build-debug dbms/gtests_dbms` but interrupted because full first-time donor gtests link path is too large in this environment
