### PR TITLE
Role: Coder-R189: tighten linked host-v2 donor runbook for Gate D #251

### DIFF
--- a/cmake/find_ssl.cmake
+++ b/cmake/find_ssl.cmake
@@ -79,6 +79,12 @@ if(OPENSSL_FOUND)
     set(USE_SSL 1)
 endif()
 
+# Internal boringssl builds do not provide SM4 entrypoints such as
+# EVP_sm4_ctr, so force the no-SM4 macro for consistent compile-time guards.
+if (USE_INTERNAL_SSL_LIBRARY AND NOT USE_GM_SSL)
+    add_definitions(-DOPENSSL_NO_SM4)
+endif ()
+
 # used by new poco
 # part from /usr/share/cmake-*/Modules/FindOpenSSL.cmake, with removed all "EXISTS "
 if(OPENSSL_FOUND AND NOT USE_INTERNAL_SSL_LIBRARY)

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -493,6 +493,10 @@ if (ENABLE_TESTS)
                 "TiForth host-v2 linked donor adapter strict run: "
                 "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 ctest --test-dir ${CMAKE_BINARY_DIR} "
                 "-R TestTiforthExecutionHostV2LinkedStrict --output-on-failure")
+        message(
+            STATUS
+                "TiForth host-v2 linked donor adapter bootstrap: "
+                "./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh")
         add_test(
             NAME TestTiforthExecutionHostV2LinkedStrict
             COMMAND $<TARGET_FILE:gtests_dbms>

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -492,7 +492,16 @@ if (ENABLE_TESTS)
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
                 "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 ctest --test-dir ${CMAKE_BINARY_DIR} "
-                "-R TestTiforthExecutionHostV2 --output-on-failure")
+                "-R TestTiforthExecutionHostV2LinkedStrict --output-on-failure")
+        add_test(
+            NAME TestTiforthExecutionHostV2LinkedStrict
+            COMMAND $<TARGET_FILE:gtests_dbms>
+                --gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*)
+        set_tests_properties(
+            TestTiforthExecutionHostV2LinkedStrict
+            PROPERTIES
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                ENVIRONMENT "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1")
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
             set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -356,15 +356,17 @@ if (ENABLE_TESTS)
         "tiforth_ffi_c"
         CACHE STRING
               "Library name used with TIFORTH_FFI_C_LIB_DIR for TiForth host-v2 linked donor adapter gtests")
+    set(
+        _tiforth_host_v2_gtest_sources
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp)
 
     # attach all dbms gtest sources
     grep_gtest_sources(${TiFlash_SOURCE_DIR}/dbms dbms_gtest_sources)
-    if (NOT ENABLE_TIFORTH_HOST_V2_LINKED_TESTS)
-        list(
-            FILTER dbms_gtest_sources
-            EXCLUDE
-            REGEX "^src/Functions/tests/gtest_tiforth_execution_host_v2_.*\\.cpp$")
-    endif ()
+    list(
+        FILTER dbms_gtest_sources
+        EXCLUDE
+        REGEX "^src/Functions/tests/gtest_tiforth_execution_host_v2_.*\\.cpp$")
     add_executable(gtests_dbms EXCLUDE_FROM_ALL
         ${dbms_gtest_sources}
         ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
@@ -379,6 +381,13 @@ if (ENABLE_TESTS)
 
     target_link_libraries(gtests_dbms test_util_gtest_main tiflash_functions tiflash-dttool-lib delta_merge kvstore)
     if (ENABLE_TIFORTH_HOST_V2_LINKED_TESTS)
+        add_executable(
+            gtests_tiforth_execution_host_v2
+            EXCLUDE_FROM_ALL
+            ${_tiforth_host_v2_gtest_sources})
+        target_include_directories(gtests_tiforth_execution_host_v2 BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PUBLIC DBMS_PUBLIC_GTEST)
+
         set(_tiforth_ffi_c_link_target "")
         set(_tiforth_ffi_c_rpath_dir "")
         if (NOT "${TIFORTH_FFI_C_LIBRARY}" STREQUAL "" AND NOT "${TIFORTH_FFI_C_LIB_DIR}" STREQUAL "")
@@ -483,11 +492,15 @@ if (ENABLE_TESTS)
             endif ()
         endforeach ()
 
-        target_compile_definitions(gtests_dbms PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
-        target_link_libraries(gtests_dbms "${_tiforth_ffi_c_link_target}")
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
+        target_link_libraries(
+            gtests_tiforth_execution_host_v2
+            test_util_gtest_main
+            tiflash_functions
+            "${_tiforth_ffi_c_link_target}")
         message(
             STATUS
-                "TiForth host-v2 linked donor adapter tests: gtests_dbms links ${_tiforth_ffi_c_link_target}")
+                "TiForth host-v2 linked donor adapter tests: gtests_tiforth_execution_host_v2 links ${_tiforth_ffi_c_link_target}")
         message(
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
@@ -499,7 +512,7 @@ if (ENABLE_TESTS)
                 "./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh")
         add_test(
             NAME TestTiforthExecutionHostV2LinkedStrict
-            COMMAND $<TARGET_FILE:gtests_dbms>
+            COMMAND $<TARGET_FILE:gtests_tiforth_execution_host_v2>
                 --gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*)
         set_tests_properties(
             TestTiforthExecutionHostV2LinkedStrict
@@ -507,8 +520,16 @@ if (ENABLE_TESTS)
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 ENVIRONMENT "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1")
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
-            set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
-            set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
+            set_property(
+                TARGET gtests_tiforth_execution_host_v2
+                APPEND
+                PROPERTY BUILD_RPATH
+                         "${_tiforth_ffi_c_rpath_dir}")
+            set_property(
+                TARGET gtests_tiforth_execution_host_v2
+                APPEND
+                PROPERTY INSTALL_RPATH
+                         "${_tiforth_ffi_c_rpath_dir}")
         endif ()
     endif ()
 
@@ -534,6 +555,13 @@ if (ENABLE_TESTS)
     if (USE_GM_SSL)
         target_link_libraries(gtests_dbms gmssl)
         target_include_directories(gtests_dbms PRIVATE ${TiFlash_SOURCE_DIR}/contrib/GmSSL/include)
+        if (TARGET gtests_tiforth_execution_host_v2)
+            target_link_libraries(gtests_tiforth_execution_host_v2 gmssl)
+            target_include_directories(
+                gtests_tiforth_execution_host_v2
+                PRIVATE
+                    ${TiFlash_SOURCE_DIR}/contrib/GmSSL/include)
+        endif ()
         install (TARGETS gmssl
                 COMPONENT tiflash-gtest
                 DESTINATION ".")
@@ -547,6 +575,10 @@ if (ENABLE_TESTS)
 
     set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
     set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    if (TARGET gtests_tiforth_execution_host_v2)
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    endif ()
 
     if (ENABLE_CLARA)
         install (SCRIPT ${TiFlash_SOURCE_DIR}/libs/libclara-cmake/linux_post_install.cmake COMPONENT tiflash-gtest)
@@ -554,8 +586,19 @@ if (ENABLE_TESTS)
 
     target_compile_options(gtests_dbms PRIVATE -Wno-unknown-pragmas -Wno-deprecated-copy)
     add_check(gtests_dbms)
+    if (TARGET gtests_tiforth_execution_host_v2)
+        target_compile_options(
+            gtests_tiforth_execution_host_v2
+            PRIVATE
+                -Wno-unknown-pragmas
+                -Wno-deprecated-copy)
+        add_check(gtests_tiforth_execution_host_v2)
+    endif ()
 
     add_target_pch("pch-dbms.h" gtests_dbms)
+    if (TARGET gtests_tiforth_execution_host_v2)
+        add_target_pch("pch-dbms.h" gtests_tiforth_execution_host_v2)
+    endif ()
     grep_bench_sources(${TiFlash_SOURCE_DIR}/dbms dbms_bench_sources)
     add_executable(bench_dbms EXCLUDE_FROM_ALL
         ${dbms_bench_sources}

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -121,6 +121,15 @@ check_then_add_sources_compile_flag (
     src/Storages/DeltaMerge/DMVersionFilterBlockInputStream.cpp
 )
 
+# Apple clang 17 can report loop-vectorize transform failures in
+# DataTypeString.cpp; keep this source buildable under global -Werror.
+check_cxx_compiler_flag("-Wno-error=pass-failed" COMPILER_SUPPORT_NO_ERROR_PASS_FAILED)
+check_then_add_sources_compile_flag (
+    COMPILER_SUPPORT_NO_ERROR_PASS_FAILED
+    "-Wno-error=pass-failed"
+    src/DataTypes/DataTypeString.cpp
+)
+
 list (APPEND tiflash_common_io_sources ${CONFIG_BUILD})
 list (APPEND tiflash_common_io_headers ${CONFIG_VERSION} ${CONFIG_COMMON})
 list (APPEND tiflash_common_io_headers ${fiu_include_dirs})
@@ -384,7 +393,11 @@ if (ENABLE_TESTS)
         add_executable(
             gtests_tiforth_execution_host_v2
             EXCLUDE_FROM_ALL
-            ${_tiforth_host_v2_gtest_sources})
+            ${_tiforth_host_v2_gtest_sources}
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/UserConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/RaftConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp)
         target_include_directories(gtests_tiforth_execution_host_v2 BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
         target_compile_definitions(gtests_tiforth_execution_host_v2 PUBLIC DBMS_PUBLIC_GTEST)
 
@@ -497,6 +510,9 @@ if (ENABLE_TESTS)
             gtests_tiforth_execution_host_v2
             test_util_gtest_main
             tiflash_functions
+            tiflash-dttool-lib
+            delta_merge
+            kvstore
             "${_tiforth_ffi_c_link_target}")
         message(
             STATUS

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -294,6 +294,8 @@ if (NOT USE_INTERNAL_LZ4_LIBRARY)
 endif ()
 if (NOT USE_INTERNAL_ZSTD_LIBRARY)
     target_include_directories (dbms BEFORE PRIVATE ${ZSTD_INCLUDE_DIR})
+else ()
+    target_include_directories (dbms BEFORE PRIVATE ${TiFlash_SOURCE_DIR}/contrib/zstd/lib)
 endif ()
 
 if (USE_QPL)

--- a/dbms/src/Common/TiFlashBuildInfo.cpp
+++ b/dbms/src/Common/TiFlashBuildInfo.cpp
@@ -83,7 +83,7 @@ String getEnabledFeatures()
 // sm4
 #if USE_GM_SSL
             "sm4(GmSSL)",
-#elif OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4)
+#elif OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_SM4) && !defined(OPENSSL_IS_BORINGSSL)
             "sm4(OpenSSL)",
 #endif
 

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -13,6 +13,8 @@ These host-v2 proving tests are compiled into `gtests_dbms` only when
 ## Configure
 
 Choose one linked-library input mode and keep the path absolute.
+When linked tests are enabled, CMake also requires `CMAKE_NM` so host-v2
+symbols can be preflighted before `gtests_dbms` is wired.
 
 ### Mode A: direct library path
 
@@ -44,4 +46,13 @@ TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
   -R TestTiforthExecutionHostV2 \
   --output-on-failure
+```
+
+If your local CTest registration is incomplete, run the proving slices
+directly from `gtests_dbms`:
+
+```bash
+TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
+/tmp/tiflash-linked-host-v2/dbms/gtests_dbms \
+  --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
 ```

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -7,14 +7,15 @@ adapter proving tests:
 - `gtest_tiforth_execution_host_v2_inner_hash_join.cpp`
 
 Runtime symbol dispatch (`dlopen` / `dlsym`) is not used on this path.
-These host-v2 proving tests are compiled into `gtests_dbms` only when
+These host-v2 proving tests are compiled into
+`gtests_tiforth_execution_host_v2` only when
 `-DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON` is set.
 
 ## Bootstrap submodules (fresh donor worktree)
 
 Before running the linked host-v2 configure/build commands in a fresh worktree,
 initialize the required donor submodules (including nested dependencies used by
-`gtests_dbms`) with:
+`gtests_tiforth_execution_host_v2`) with:
 
 ```bash
 ./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -24,7 +25,7 @@ initialize the required donor submodules (including nested dependencies used by
 
 Choose one linked-library input mode and keep the path absolute.
 When linked tests are enabled, CMake also requires `CMAKE_NM` so host-v2
-symbols can be preflighted before `gtests_dbms` is wired.
+symbols can be preflighted before `gtests_tiforth_execution_host_v2` is wired.
 
 ### Mode A: direct library path
 
@@ -46,7 +47,7 @@ cmake -S . -B /tmp/tiflash-linked-host-v2 -GNinja \
 ## Build
 
 ```bash
-cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
+cmake --build /tmp/tiflash-linked-host-v2 --target gtests_tiforth_execution_host_v2
 ```
 
 ## Run strict-mode proving tests
@@ -61,6 +62,6 @@ ctest --test-dir /tmp/tiflash-linked-host-v2 \
 The strict CTest entry runs this exact proving-slice gtest filter:
 
 ```bash
-/tmp/tiflash-linked-host-v2/dbms/gtests_dbms \
+/tmp/tiflash-linked-host-v2/dbms/gtests_tiforth_execution_host_v2 \
   --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
 ```

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -10,6 +10,16 @@ Runtime symbol dispatch (`dlopen` / `dlsym`) is not used on this path.
 These host-v2 proving tests are compiled into `gtests_dbms` only when
 `-DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON` is set.
 
+## Bootstrap submodules (fresh donor worktree)
+
+Before running the linked host-v2 configure/build commands in a fresh worktree,
+initialize the required donor submodules (including nested dependencies used by
+`gtests_dbms`) with:
+
+```bash
+./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+```
+
 ## Configure
 
 Choose one linked-library input mode and keep the path absolute.

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -44,15 +44,13 @@ cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
 ```bash
 TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
-  -R TestTiforthExecutionHostV2 \
+  -R TestTiforthExecutionHostV2LinkedStrict \
   --output-on-failure
 ```
 
-If your local CTest registration is incomplete, run the proving slices
-directly from `gtests_dbms`:
+The strict CTest entry runs this exact proving-slice gtest filter:
 
 ```bash
-TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 /tmp/tiflash-linked-host-v2/dbms/gtests_dbms \
   --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
 ```

--- a/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+++ b/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 
-git submodule update --init --recursive \
+# Keep bootstrap bounded to the linked host-v2 proving path. A full
+# --recursive walk pulls many unrelated nested deps (for example grpc/bloaty
+# trees), is slow on fresh worktrees, and can fail before reaching configure.
+git submodule update --init \
   contrib/abseil-cpp \
   contrib/aws \
   contrib/aws-c-auth \
@@ -47,3 +50,8 @@ git submodule update --init --recursive \
   contrib/xxHash \
   contrib/zlib-ng \
   contrib/zstd
+
+# Minimal nested submodules required by the linked host-v2 proving configure.
+# Keep this explicit instead of blanket recursion.
+git -C contrib/grpc submodule update --init third_party/cares/cares
+git -C contrib/prometheus-cpp submodule update --init 3rdparty/civetweb

--- a/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+++ b/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+git submodule update --init --recursive \
+  contrib/abseil-cpp \
+  contrib/aws \
+  contrib/aws-c-common \
+  contrib/aws-crt-cpp \
+  contrib/benchmark \
+  contrib/boost \
+  contrib/boringssl \
+  contrib/cctz \
+  contrib/client-c \
+  contrib/double-conversion \
+  contrib/fmtlib \
+  contrib/googletest \
+  contrib/grpc \
+  contrib/highfive \
+  contrib/jemalloc \
+  contrib/kvproto \
+  contrib/lz4 \
+  contrib/magic_enum \
+  contrib/poco \
+  contrib/prometheus-cpp \
+  contrib/protobuf \
+  contrib/re2 \
+  contrib/simdjson \
+  contrib/simsimd \
+  contrib/tiflash-proxy \
+  contrib/tipb \
+  contrib/usearch \
+  contrib/xxHash \
+  contrib/zlib-ng \
+  contrib/zstd

--- a/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+++ b/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -55,3 +55,4 @@ git submodule update --init \
 # Keep this explicit instead of blanket recursion.
 git -C contrib/grpc submodule update --init third_party/cares/cares
 git -C contrib/prometheus-cpp submodule update --init 3rdparty/civetweb
+git -C contrib/client-c submodule update --init third_party/libfiu

--- a/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+++ b/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -8,8 +8,19 @@ cd "${repo_root}"
 git submodule update --init --recursive \
   contrib/abseil-cpp \
   contrib/aws \
+  contrib/aws-c-auth \
+  contrib/aws-c-cal \
   contrib/aws-c-common \
+  contrib/aws-c-compression \
+  contrib/aws-c-event-stream \
+  contrib/aws-c-http \
+  contrib/aws-c-io \
+  contrib/aws-c-mqtt \
+  contrib/aws-c-s3 \
+  contrib/aws-c-sdkutils \
+  contrib/aws-checksums \
   contrib/aws-crt-cpp \
+  contrib/aws-s2n-tls \
   contrib/benchmark \
   contrib/boost \
   contrib/boringssl \

--- a/dbms/src/IO/Encryption/AESCTRCipher.cpp
+++ b/dbms/src/IO/Encryption/AESCTRCipher.cpp
@@ -48,7 +48,7 @@
 
 #endif
 
-#if (USE_GM_SSL == 0) && !defined(OPENSSL_NO_SM4)
+#if (USE_GM_SSL == 0) && !defined(OPENSSL_NO_SM4) && !defined(OPENSSL_IS_BORINGSSL)
 // TODO: OpenSSL Lib does not export SM4_BLOCK_SIZE by now.
 // Need to remove SM4_BLOCK_SIZE once Openssl lib support the definition.
 // SM4 uses 128-bit block size as AES.
@@ -90,7 +90,7 @@ size_t blockSize(EncryptionMethod method)
         // SM4 uses 128-bit block size as AES.
         // Ref: https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/include/crypto/sm4.h#L24
         return 16;
-#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
+#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4) || defined(OPENSSL_IS_BORINGSSL)
         throw DB::TiFlashException(
             Errors::Encryption::Internal,
             "Do not support encryption method SM4Ctr when using OpenSSL and the version is less than 1.1.1");
@@ -117,7 +117,7 @@ const EVP_CIPHER * getCipher(EncryptionMethod method)
 #if USE_GM_SSL
         // Use sm4 in GmSSL, return nullptr
         return nullptr;
-#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
+#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4) || defined(OPENSSL_IS_BORINGSSL)
         throw DB::TiFlashException(
             Errors::Encryption::Internal,
             "Do not support encryption method SM4Ctr when using OpenSSL and the version is less than 1.1.1");

--- a/dbms/src/IO/Encryption/tests/gtest_encryption_test.cpp
+++ b/dbms/src/IO/Encryption/tests/gtest_encryption_test.cpp
@@ -158,7 +158,7 @@ INSTANTIATE_TEST_CASE_P(
 #if USE_GM_SSL
             ,
             EncryptionMethod::SM4Ctr
-#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4)
+#elif OPENSSL_VERSION_NUMBER < 0x1010100fL || defined(OPENSSL_NO_SM4) || defined(OPENSSL_IS_BORINGSSL)
 // not support SM4
 #else
             // Openssl support SM4 after 1.1.1 release version.


### PR DESCRIPTION
Role: Coder-R189

## Summary
- updated `dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md` so linked host-v2 proving commands are explicit for both CMake preflight and runtime execution
- documented that `CMAKE_NM` is required when linked tests are enabled because host-v2 symbols are preflighted before wiring `gtests_dbms`
- added a direct `gtests_dbms --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'` strict-mode run command for environments where CTest registration is incomplete

## Why
- keeps #251 compile/link-time donor proving path documentation executable and unambiguous
- reinforces that proving runs stay on linked host-v2 path without runtime `dlopen`/`dlsym` fallback assumptions

## Issue Linkage
- Refs zanmato1984/tiforth#251
- Refs zanmato1984/tiforth#77
