### PR TITLE
Role: Coder-R195: promote reusable host-v2 donor adapter path for Gate D #252

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -356,6 +356,9 @@ if (ENABLE_TESTS)
         "tiforth_ffi_c"
         CACHE STRING
               "Library name used with TIFORTH_FFI_C_LIB_DIR for TiForth host-v2 linked donor adapter gtests")
+    set(_tiforth_host_v2_gtest_sources
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp)
 
     # attach all dbms gtest sources
     grep_gtest_sources(${TiFlash_SOURCE_DIR}/dbms dbms_gtest_sources)
@@ -485,17 +488,46 @@ if (ENABLE_TESTS)
 
         target_compile_definitions(gtests_dbms PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
         target_link_libraries(gtests_dbms "${_tiforth_ffi_c_link_target}")
+        add_executable(gtests_tiforth_execution_host_v2 EXCLUDE_FROM_ALL
+            ${_tiforth_host_v2_gtest_sources}
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/UserConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/RaftConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp
+        )
+        target_include_directories(gtests_tiforth_execution_host_v2 BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PUBLIC DBMS_PUBLIC_GTEST)
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
+        target_link_libraries(
+            gtests_tiforth_execution_host_v2
+            test_util_gtest_main
+            tiflash_functions
+            tiflash-dttool-lib
+            delta_merge
+            kvstore
+            "${_tiforth_ffi_c_link_target}")
+        target_compile_options(gtests_tiforth_execution_host_v2 PRIVATE -Wno-unknown-pragmas -Wno-deprecated-copy)
+        add_target_pch("pch-dbms.h" gtests_tiforth_execution_host_v2)
+        add_test(
+            NAME TestTiforthExecutionHostV2LinkedStrict
+            COMMAND
+                "${CMAKE_COMMAND}" -E env TIFORTH_REQUIRE_RUNTIME_EXECUTION=1
+                "$<TARGET_FILE:gtests_tiforth_execution_host_v2>"
+                "--gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*")
         message(
             STATUS
-                "TiForth host-v2 linked donor adapter tests: gtests_dbms links ${_tiforth_ffi_c_link_target}")
+                "TiForth host-v2 linked donor adapter tests: gtests_dbms and "
+                "gtests_tiforth_execution_host_v2 link ${_tiforth_ffi_c_link_target}")
         message(
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
                 "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 ctest --test-dir ${CMAKE_BINARY_DIR} "
-                "-R TestTiforthExecutionHostV2 --output-on-failure")
+                "-R TestTiforthExecutionHostV2LinkedStrict --output-on-failure")
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
             set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
+            set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
+            set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
         endif ()
     endif ()
 
@@ -534,6 +566,10 @@ if (ENABLE_TESTS)
 
     set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
     set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    if (TARGET gtests_tiforth_execution_host_v2)
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    endif ()
 
     if (ENABLE_CLARA)
         install (SCRIPT ${TiFlash_SOURCE_DIR}/libs/libclara-cmake/linux_post_install.cmake COMPONENT tiflash-gtest)

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -641,7 +641,10 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
     uint32_t ownership_mode,
     uint32_t ambient_requirement_mask,
     uint32_t session_charset,
-    uint32_t default_collation)
+    uint32_t default_collation,
+    uint32_t max_block_size,
+    bool build_end_with_output,
+    bool probe_end_with_output)
 {
     TiforthExecutionBuildRequestV2 build_request{};
     build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -654,7 +657,7 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
     build_request.decimal_precision = 0;
     build_request.decimal_scale_is_set = false;
     build_request.decimal_scale = 0;
-    build_request.max_block_size = 0;
+    build_request.max_block_size = max_block_size;
 
     ExecutionHandles handles(api);
     TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
@@ -700,22 +703,42 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
     drive_input_rows(build_rows, INPUT_ID_BUILD);
 
     auto status = makeStatus();
-    auto output = makeBatch();
-    api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
-    ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
-    result.warning_count += status.warning_count;
-    appendJoinOutputRows(output, result.rows);
-    drainJoinOutput(api, instance, status, result);
+    if (build_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        ensureStatusKindOk("drive_end_of_input(build)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
 
     drive_input_rows(probe_rows, INPUT_ID_PROBE);
 
     status = makeStatus();
-    output = makeBatch();
-    api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
-    ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
-    result.warning_count += status.warning_count;
-    appendJoinOutputRows(output, result.rows);
-    drainJoinOutput(api, instance, status, result);
+    if (probe_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        ensureStatusKindOk("drive_end_of_input(probe)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
 
     status = makeStatus();
     api.finish(instance, &status);
@@ -734,7 +757,10 @@ JoinRunResult runJoinInt64KeyInt64Payload(
     uint32_t ownership_mode,
     uint32_t ambient_requirement_mask,
     uint32_t session_charset,
-    uint32_t default_collation)
+    uint32_t default_collation,
+    uint32_t max_block_size,
+    bool build_end_with_output,
+    bool probe_end_with_output)
 {
     TiforthExecutionBuildRequestV2 build_request{};
     build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -747,7 +773,7 @@ JoinRunResult runJoinInt64KeyInt64Payload(
     build_request.decimal_precision = 0;
     build_request.decimal_scale_is_set = false;
     build_request.decimal_scale = 0;
-    build_request.max_block_size = 0;
+    build_request.max_block_size = max_block_size;
 
     ExecutionHandles handles(api);
     TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
@@ -793,22 +819,42 @@ JoinRunResult runJoinInt64KeyInt64Payload(
     drive_input_rows(build_rows, INPUT_ID_BUILD);
 
     auto status = makeStatus();
-    auto output = makeBatch();
-    api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
-    ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
-    result.warning_count += status.warning_count;
-    appendJoinOutputRows(output, result.rows);
-    drainJoinOutput(api, instance, status, result);
+    if (build_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        ensureStatusKindOk("drive_end_of_input(build)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
 
     drive_input_rows(probe_rows, INPUT_ID_PROBE);
 
     status = makeStatus();
-    output = makeBatch();
-    api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
-    ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
-    result.warning_count += status.warning_count;
-    appendJoinOutputRows(output, result.rows);
-    drainJoinOutput(api, instance, status, result);
+    if (probe_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        ensureStatusKindOk("drive_end_of_input(probe)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
 
     status = makeStatus();
     api.finish(instance, &status);

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -1,0 +1,840 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Functions/TiforthExecutionHostV2Adapter.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <fmt/core.h>
+#include <stdexcept>
+#include <utility>
+
+namespace DB::Tiforth
+{
+namespace
+{
+
+extern "C"
+{
+void tiforth_execution_host_v2_build(
+    const TiforthExecutionBuildRequestV2 * request,
+    TiforthStatusV2 * out_status,
+    TiforthExecutionExecutableHandleV2 ** out_executable);
+void tiforth_execution_host_v2_open(
+    const TiforthExecutionExecutableHandleV2 * executable,
+    TiforthStatusV2 * out_status,
+    TiforthExecutionInstanceHandleV2 ** out_instance);
+void tiforth_execution_host_v2_drive_input_batch(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    const TiforthBatchViewV2 * input,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_drive_end_of_input(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    TiforthStatusV2 * out_status);
+void tiforth_execution_host_v2_drive_end_of_input_with_output(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_continue_output(
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_finish(
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 * out_status);
+void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
+void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
+}
+
+String statusMessage(const TiforthStatusV2 & status)
+{
+    const size_t msg_len = strnlen(status.message, sizeof(status.message));
+    return String(status.message, msg_len);
+}
+
+[[noreturn]] void throwStatusError(const char * step, const TiforthStatusV2 & status)
+{
+    throw std::runtime_error(
+        fmt::format(
+            "{} failed: kind={} code={} warning_count={} message={}",
+            step,
+            status.kind,
+            status.code,
+            status.warning_count,
+            statusMessage(status)));
+}
+
+void ensureStatusKindOk(const char * step, const TiforthStatusV2 & status)
+{
+    if (status.kind != STATUS_KIND_OK)
+        throwStatusError(step, status);
+}
+
+void ensureStatusOk(const char * step, const TiforthStatusV2 & status)
+{
+    ensureStatusKindOk(step, status);
+    if (status.code != STATUS_CODE_NONE)
+        throwStatusError(step, status);
+}
+
+TiforthStatusV2 makeStatus()
+{
+    TiforthStatusV2 status{};
+    status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    return status;
+}
+
+TiforthBatchViewV2 makeBatch()
+{
+    TiforthBatchViewV2 batch{};
+    batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    return batch;
+}
+
+bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
+{
+    if (column.null_bitmap == nullptr || row_count == 0)
+        return true;
+    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
+    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
+}
+
+String uint128ToString(unsigned __int128 value)
+{
+    if (value == 0)
+        return "0";
+
+    String digits;
+    while (value > 0)
+    {
+        const uint8_t digit = static_cast<uint8_t>(value % 10);
+        digits.push_back(static_cast<char>('0' + digit));
+        value /= 10;
+    }
+    std::reverse(digits.begin(), digits.end());
+    return digits;
+}
+
+String formatDecimal128(__int128 value, int8_t scale)
+{
+    const bool negative = value < 0;
+    unsigned __int128 abs_value;
+    if (negative)
+    {
+        // avoid overflow when value is the smallest signed 128-bit number
+        abs_value = static_cast<unsigned __int128>(-(value + 1));
+        abs_value += 1;
+    }
+    else
+    {
+        abs_value = static_cast<unsigned __int128>(value);
+    }
+
+    if (scale == 0)
+    {
+        String rendered = uint128ToString(abs_value);
+        if (negative)
+            rendered.insert(rendered.begin(), '-');
+        return rendered;
+    }
+
+    String digits = uint128ToString(abs_value);
+    const size_t scale_digits = static_cast<size_t>(scale);
+    if (digits.size() <= scale_digits)
+        digits.insert(0, scale_digits + 1 - digits.size(), '0');
+
+    const size_t split = digits.size() - scale_digits;
+    String rendered = fmt::format("{}.{}", digits.substr(0, split), digits.substr(split));
+    if (negative)
+        rendered.insert(rendered.begin(), '-');
+    return rendered;
+}
+
+void appendCastOutputRows(const TiforthBatchViewV2 & output, std::vector<std::optional<String>> & rows)
+{
+    if (output.row_count == 0)
+        return;
+
+    if (output.column_count != 1)
+    {
+        throw std::runtime_error(
+            fmt::format("cast output has {} columns, expected 1", output.column_count));
+    }
+    if (output.columns == nullptr)
+        throw std::runtime_error("cast output columns is null");
+
+    const auto & output_column = output.columns[0];
+    if (output_column.physical_type != PHYSICAL_TYPE_DECIMAL128)
+    {
+        throw std::runtime_error(
+            fmt::format(
+                "cast output physical_type={}, expected decimal128",
+                output_column.physical_type));
+    }
+
+    const auto * decimal_values = reinterpret_cast<const __int128 *>(output_column.decimal128_words);
+    if (decimal_values == nullptr)
+        throw std::runtime_error("cast output decimal128_words is null");
+
+    decimal_values += output_column.row_offset;
+    for (size_t row = 0; row < output.row_count; ++row)
+    {
+        if (!isValidRow(output_column, output.row_count, row))
+        {
+            rows.push_back(std::nullopt);
+            continue;
+        }
+        rows.push_back(formatDecimal128(decimal_values[row], output_column.decimal_scale));
+    }
+}
+
+void appendJoinOutputRows(const TiforthBatchViewV2 & output, std::vector<JoinOutputRow> & rows)
+{
+    if (output.row_count == 0)
+        return;
+
+    if (output.column_count != 2)
+    {
+        throw std::runtime_error(
+            fmt::format("join output has {} columns, expected 2", output.column_count));
+    }
+    if (output.columns == nullptr)
+        throw std::runtime_error("join output columns is null");
+
+    const auto & build_payload = output.columns[0];
+    const auto & probe_payload = output.columns[1];
+
+    if (build_payload.physical_type != PHYSICAL_TYPE_INT64 || probe_payload.physical_type != PHYSICAL_TYPE_INT64)
+    {
+        throw std::runtime_error(
+            fmt::format(
+                "join output physical types are [{}, {}], expected [int64, int64]",
+                build_payload.physical_type,
+                probe_payload.physical_type));
+    }
+
+    if (build_payload.values == nullptr || probe_payload.values == nullptr)
+        throw std::runtime_error("join output value pointer is null");
+
+    const auto * build_values = build_payload.values + build_payload.row_offset;
+    const auto * probe_values = probe_payload.values + probe_payload.row_offset;
+
+    for (size_t row = 0; row < output.row_count; ++row)
+    {
+        const auto build_value = isValidRow(build_payload, output.row_count, row)
+            ? std::optional<int64_t>(build_values[row])
+            : std::nullopt;
+        const auto probe_value = isValidRow(probe_payload, output.row_count, row)
+            ? std::optional<int64_t>(probe_values[row])
+            : std::nullopt;
+        rows.emplace_back(build_value, probe_value);
+    }
+}
+
+struct Utf8BatchOwned
+{
+    std::vector<uint8_t> null_bitmap;
+    std::vector<int32_t> offsets;
+    String data;
+    TiforthExecutionColumnViewV2 column{};
+    TiforthBatchViewV2 batch{};
+
+    Utf8BatchOwned(const std::vector<std::optional<String>> & rows, uint32_t ownership_mode)
+    {
+        null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+        offsets.reserve(rows.size() + 1);
+        offsets.push_back(0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].has_value())
+            {
+                null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                data.append(rows[i].value());
+            }
+            offsets.push_back(static_cast<int32_t>(data.size()));
+        }
+
+        column.physical_type = PHYSICAL_TYPE_UTF8;
+        column.null_bitmap = null_bitmap.empty() ? nullptr : null_bitmap.data();
+        column.null_bitmap_bit_offset = 0;
+        column.row_offset = 0;
+        column.values = nullptr;
+        column.offsets = offsets.data();
+        column.data = data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(data.data());
+        column.decimal128_words = nullptr;
+        column.decimal_precision_is_set = false;
+        column.decimal_precision = 0;
+        column.decimal_scale_is_set = false;
+        column.decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 1;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = &column;
+    }
+};
+
+struct Utf8Int64JoinBatchOwned
+{
+    std::vector<uint8_t> key_null_bitmap;
+    std::vector<int32_t> key_offsets;
+    String key_data;
+
+    std::vector<int64_t> payload_values;
+    std::vector<uint8_t> payload_null_bitmap;
+
+    TiforthExecutionColumnViewV2 columns[2]{};
+    TiforthBatchViewV2 batch{};
+
+    Utf8Int64JoinBatchOwned(const std::vector<Utf8Int64Row> & rows, uint32_t ownership_mode)
+    {
+        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+        key_offsets.reserve(rows.size() + 1);
+        key_offsets.push_back(0);
+
+        payload_values.reserve(rows.size());
+        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].first.has_value())
+            {
+                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                key_data.append(rows[i].first.value());
+            }
+            key_offsets.push_back(static_cast<int32_t>(key_data.size()));
+
+            if (rows[i].second.has_value())
+            {
+                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                payload_values.push_back(rows[i].second.value());
+            }
+            else
+            {
+                payload_values.push_back(0);
+            }
+        }
+
+        columns[0].physical_type = PHYSICAL_TYPE_UTF8;
+        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
+        columns[0].null_bitmap_bit_offset = 0;
+        columns[0].row_offset = 0;
+        columns[0].values = nullptr;
+        columns[0].offsets = key_offsets.data();
+        columns[0].data = key_data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(key_data.data());
+        columns[0].decimal128_words = nullptr;
+        columns[0].decimal_precision_is_set = false;
+        columns[0].decimal_precision = 0;
+        columns[0].decimal_scale_is_set = false;
+        columns[0].decimal_scale = 0;
+
+        columns[1].physical_type = PHYSICAL_TYPE_INT64;
+        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
+        columns[1].null_bitmap_bit_offset = 0;
+        columns[1].row_offset = 0;
+        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
+        columns[1].offsets = nullptr;
+        columns[1].data = nullptr;
+        columns[1].decimal128_words = nullptr;
+        columns[1].decimal_precision_is_set = false;
+        columns[1].decimal_precision = 0;
+        columns[1].decimal_scale_is_set = false;
+        columns[1].decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 2;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = columns;
+    }
+};
+
+struct Int64Int64JoinBatchOwned
+{
+    std::vector<int64_t> key_values;
+    std::vector<uint8_t> key_null_bitmap;
+
+    std::vector<int64_t> payload_values;
+    std::vector<uint8_t> payload_null_bitmap;
+
+    TiforthExecutionColumnViewV2 columns[2]{};
+    TiforthBatchViewV2 batch{};
+
+    Int64Int64JoinBatchOwned(const std::vector<Int64Int64Row> & rows, uint32_t ownership_mode)
+    {
+        key_values.reserve(rows.size());
+        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        payload_values.reserve(rows.size());
+        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].first.has_value())
+            {
+                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                key_values.push_back(rows[i].first.value());
+            }
+            else
+            {
+                key_values.push_back(0);
+            }
+
+            if (rows[i].second.has_value())
+            {
+                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                payload_values.push_back(rows[i].second.value());
+            }
+            else
+            {
+                payload_values.push_back(0);
+            }
+        }
+
+        columns[0].physical_type = PHYSICAL_TYPE_INT64;
+        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
+        columns[0].null_bitmap_bit_offset = 0;
+        columns[0].row_offset = 0;
+        columns[0].values = key_values.empty() ? nullptr : key_values.data();
+        columns[0].offsets = nullptr;
+        columns[0].data = nullptr;
+        columns[0].decimal128_words = nullptr;
+        columns[0].decimal_precision_is_set = false;
+        columns[0].decimal_precision = 0;
+        columns[0].decimal_scale_is_set = false;
+        columns[0].decimal_scale = 0;
+
+        columns[1].physical_type = PHYSICAL_TYPE_INT64;
+        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
+        columns[1].null_bitmap_bit_offset = 0;
+        columns[1].row_offset = 0;
+        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
+        columns[1].offsets = nullptr;
+        columns[1].data = nullptr;
+        columns[1].decimal128_words = nullptr;
+        columns[1].decimal_precision_is_set = false;
+        columns[1].decimal_precision = 0;
+        columns[1].decimal_scale_is_set = false;
+        columns[1].decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 2;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = columns;
+    }
+};
+
+class ExecutionHandles
+{
+public:
+    explicit ExecutionHandles(const TiforthExecutionHostV2Api & api_)
+        : api(api_)
+    {}
+
+    ExecutionHandles(const ExecutionHandles &) = delete;
+    ExecutionHandles & operator=(const ExecutionHandles &) = delete;
+
+    ~ExecutionHandles()
+    {
+        if (instance != nullptr)
+            api.release_instance(instance);
+        if (executable != nullptr)
+            api.release_executable(executable);
+    }
+
+    TiforthExecutionInstanceHandleV2 * buildAndOpen(const TiforthExecutionBuildRequestV2 & request)
+    {
+        auto status = makeStatus();
+        api.build(&request, &status, &executable);
+        ensureStatusOk("build", status);
+        if (executable == nullptr)
+            throw std::runtime_error("build returned null executable");
+
+        status = makeStatus();
+        api.open(executable, &status, &instance);
+        ensureStatusOk("open", status);
+        if (instance == nullptr)
+            throw std::runtime_error("open returned null instance");
+
+        return instance;
+    }
+
+private:
+    const TiforthExecutionHostV2Api & api;
+    TiforthExecutionExecutableHandleV2 * executable = nullptr;
+    TiforthExecutionInstanceHandleV2 * instance = nullptr;
+};
+
+void drainJoinOutput(
+    const TiforthExecutionHostV2Api & api,
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 & status,
+    JoinRunResult & result)
+{
+    while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
+    {
+        auto continued_output = makeBatch();
+        status = makeStatus();
+        api.continue_output(instance, &status, &continued_output);
+        ensureStatusKindOk("continue_output", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(continued_output, result.rows);
+    }
+
+    if (status.code != STATUS_CODE_NONE)
+    {
+        throw std::runtime_error(
+            fmt::format("join produced unexpected status code {}", status.code));
+    }
+}
+
+} // namespace
+
+std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
+{
+#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
+    (void)error;
+
+    TiforthExecutionHostV2Api api;
+    api.build = tiforth_execution_host_v2_build;
+    api.open = tiforth_execution_host_v2_open;
+    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
+    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
+    api.drive_end_of_input_with_output = tiforth_execution_host_v2_drive_end_of_input_with_output;
+    api.continue_output = tiforth_execution_host_v2_continue_output;
+    api.finish = tiforth_execution_host_v2_finish;
+    api.release_executable = tiforth_execution_host_v2_release_executable;
+    api.release_instance = tiforth_execution_host_v2_release_instance;
+    return api;
+#else
+    error
+        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
+          "-DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> to run this donor adapter test";
+    return std::nullopt;
+#endif
+}
+
+bool requiresStrictRuntimeExecution()
+{
+    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
+    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
+}
+
+CastRunResult runCastUtf8ToDecimal(
+    const TiforthExecutionHostV2Api & api,
+    const std::vector<std::optional<String>> & input,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t sql_mode,
+    uint8_t decimal_precision,
+    int8_t decimal_scale)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = PLAN_KIND_CAST_UTF8_TO_DECIMAL;
+    build_request.ambient_requirement_mask = AMBIENT_REQUIREMENT_SQL_MODE;
+    build_request.sql_mode = sql_mode;
+    build_request.session_charset = 0;
+    build_request.default_collation = 0;
+    build_request.decimal_precision_is_set = true;
+    build_request.decimal_precision = decimal_precision;
+    build_request.decimal_scale_is_set = true;
+    build_request.decimal_scale = decimal_scale;
+    build_request.max_block_size = 0;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    CastRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    const size_t chunk_size = std::max<size_t>(1, (input.size() + partition_count - 1) / partition_count);
+    std::vector<Utf8BatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+    {
+        const size_t batch_count = input.empty() ? 0 : (input.size() + chunk_size - 1) / chunk_size;
+        retained_batches.reserve(batch_count);
+    }
+
+    for (size_t start = 0; start < input.size(); start += chunk_size)
+    {
+        const size_t end = std::min(input.size(), start + chunk_size);
+        std::vector<std::optional<String>> batch_rows(
+            input.begin() + static_cast<ptrdiff_t>(start),
+            input.begin() + static_cast<ptrdiff_t>(end));
+
+        const TiforthBatchViewV2 * input_batch = nullptr;
+        std::optional<Utf8BatchOwned> borrowed_batch;
+        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        {
+            retained_batches.emplace_back(batch_rows, ownership_mode);
+            input_batch = &retained_batches.back().batch;
+        }
+        else
+        {
+            borrowed_batch.emplace(batch_rows, ownership_mode);
+            input_batch = &borrowed_batch->batch;
+        }
+
+        auto status = makeStatus();
+        auto output = makeBatch();
+        api.drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
+        ensureStatusOk("drive_input_batch", status);
+        result.warning_count += status.warning_count;
+        appendCastOutputRows(output, result.output);
+    }
+
+    auto status = makeStatus();
+    api.drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
+    ensureStatusOk("drive_end_of_input", status);
+
+    auto continued_output = makeBatch();
+    status = makeStatus();
+    api.continue_output(instance, &status, &continued_output);
+    if (status.kind == STATUS_KIND_OK)
+    {
+        if (status.code != STATUS_CODE_NONE)
+            throwStatusError("continue_output", status);
+        if (continued_output.row_count != 0 || continued_output.column_count != 0)
+        {
+            throw std::runtime_error(
+                "continue_output returned unexpected rows for scalar cast execution");
+        }
+    }
+    else if (!(status.kind == STATUS_KIND_PROTOCOL_ERROR && status.code == STATUS_CODE_INSTANCE_FINISH_ONLY))
+    {
+        throwStatusError("continue_output", status);
+    }
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    return result;
+}
+
+JoinRunResult runJoinUtf8KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Utf8Int64Row> & build_rows,
+    const std::vector<Utf8Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = plan_kind;
+    build_request.ambient_requirement_mask = ambient_requirement_mask;
+    build_request.sql_mode = 0;
+    build_request.session_charset = session_charset;
+    build_request.default_collation = default_collation;
+    build_request.decimal_precision_is_set = false;
+    build_request.decimal_precision = 0;
+    build_request.decimal_scale_is_set = false;
+    build_request.decimal_scale = 0;
+    build_request.max_block_size = 0;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    JoinRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    std::vector<Utf8Int64JoinBatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        retained_batches.reserve(8);
+
+    auto drive_input_rows = [&](const std::vector<Utf8Int64Row> & rows, uint32_t input_id) {
+        const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
+        for (size_t start = 0; start < rows.size(); start += chunk_size)
+        {
+            const size_t end = std::min(rows.size(), start + chunk_size);
+            std::vector<Utf8Int64Row> chunk(
+                rows.begin() + static_cast<ptrdiff_t>(start),
+                rows.begin() + static_cast<ptrdiff_t>(end));
+
+            const TiforthBatchViewV2 * input_batch = nullptr;
+            std::optional<Utf8Int64JoinBatchOwned> borrowed_batch;
+            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+            {
+                retained_batches.emplace_back(chunk, ownership_mode);
+                input_batch = &retained_batches.back().batch;
+            }
+            else
+            {
+                borrowed_batch.emplace(chunk, ownership_mode);
+                input_batch = &borrowed_batch->batch;
+            }
+
+            auto status = makeStatus();
+            auto output = makeBatch();
+            api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+            ensureStatusKindOk("drive_input_batch", status);
+            result.warning_count += status.warning_count;
+            appendJoinOutputRows(output, result.rows);
+            drainJoinOutput(api, instance, status, result);
+        }
+    };
+
+    drive_input_rows(build_rows, INPUT_ID_BUILD);
+
+    auto status = makeStatus();
+    auto output = makeBatch();
+    api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+    ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+    result.warning_count += status.warning_count;
+    appendJoinOutputRows(output, result.rows);
+    drainJoinOutput(api, instance, status, result);
+
+    drive_input_rows(probe_rows, INPUT_ID_PROBE);
+
+    status = makeStatus();
+    output = makeBatch();
+    api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+    ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+    result.warning_count += status.warning_count;
+    appendJoinOutputRows(output, result.rows);
+    drainJoinOutput(api, instance, status, result);
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    result.rows = canonicalizeJoinRows(std::move(result.rows));
+    return result;
+}
+
+JoinRunResult runJoinInt64KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Int64Int64Row> & build_rows,
+    const std::vector<Int64Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = plan_kind;
+    build_request.ambient_requirement_mask = ambient_requirement_mask;
+    build_request.sql_mode = 0;
+    build_request.session_charset = session_charset;
+    build_request.default_collation = default_collation;
+    build_request.decimal_precision_is_set = false;
+    build_request.decimal_precision = 0;
+    build_request.decimal_scale_is_set = false;
+    build_request.decimal_scale = 0;
+    build_request.max_block_size = 0;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    JoinRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    std::vector<Int64Int64JoinBatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        retained_batches.reserve(8);
+
+    auto drive_input_rows = [&](const std::vector<Int64Int64Row> & rows, uint32_t input_id) {
+        const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
+        for (size_t start = 0; start < rows.size(); start += chunk_size)
+        {
+            const size_t end = std::min(rows.size(), start + chunk_size);
+            std::vector<Int64Int64Row> chunk(
+                rows.begin() + static_cast<ptrdiff_t>(start),
+                rows.begin() + static_cast<ptrdiff_t>(end));
+
+            const TiforthBatchViewV2 * input_batch = nullptr;
+            std::optional<Int64Int64JoinBatchOwned> borrowed_batch;
+            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+            {
+                retained_batches.emplace_back(chunk, ownership_mode);
+                input_batch = &retained_batches.back().batch;
+            }
+            else
+            {
+                borrowed_batch.emplace(chunk, ownership_mode);
+                input_batch = &borrowed_batch->batch;
+            }
+
+            auto status = makeStatus();
+            auto output = makeBatch();
+            api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+            ensureStatusKindOk("drive_input_batch", status);
+            result.warning_count += status.warning_count;
+            appendJoinOutputRows(output, result.rows);
+            drainJoinOutput(api, instance, status, result);
+        }
+    };
+
+    drive_input_rows(build_rows, INPUT_ID_BUILD);
+
+    auto status = makeStatus();
+    auto output = makeBatch();
+    api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+    ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+    result.warning_count += status.warning_count;
+    appendJoinOutputRows(output, result.rows);
+    drainJoinOutput(api, instance, status, result);
+
+    drive_input_rows(probe_rows, INPUT_ID_PROBE);
+
+    status = makeStatus();
+    output = makeBatch();
+    api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+    ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+    result.warning_count += status.warning_count;
+    appendJoinOutputRows(output, result.rows);
+    drainJoinOutput(api, instance, status, result);
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    result.rows = canonicalizeJoinRows(std::move(result.rows));
+    return result;
+}
+
+std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows)
+{
+    const auto rank_value = [](const std::optional<int64_t> & value) {
+        return std::make_pair(value.has_value() ? 1 : 0, value.value_or(0));
+    };
+
+    std::sort(
+        rows.begin(),
+        rows.end(),
+        [&](const JoinOutputRow & lhs, const JoinOutputRow & rhs) {
+            const auto lhs_build = rank_value(lhs.first);
+            const auto rhs_build = rank_value(rhs.first);
+            if (lhs_build != rhs_build)
+                return lhs_build < rhs_build;
+            return rank_value(lhs.second) < rank_value(rhs.second);
+        });
+    return rows;
+}
+
+} // namespace DB::Tiforth

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
@@ -184,7 +184,10 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
     uint32_t ownership_mode,
     uint32_t ambient_requirement_mask,
     uint32_t session_charset,
-    uint32_t default_collation);
+    uint32_t default_collation,
+    uint32_t max_block_size = 0,
+    bool build_end_with_output = true,
+    bool probe_end_with_output = true);
 
 JoinRunResult runJoinInt64KeyInt64Payload(
     const TiforthExecutionHostV2Api & api,
@@ -195,7 +198,10 @@ JoinRunResult runJoinInt64KeyInt64Payload(
     uint32_t ownership_mode,
     uint32_t ambient_requirement_mask,
     uint32_t session_charset,
-    uint32_t default_collation);
+    uint32_t default_collation,
+    uint32_t max_block_size = 0,
+    bool build_end_with_output = true,
+    bool probe_end_with_output = true);
 
 std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows);
 

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
@@ -1,0 +1,202 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Core/Types.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace DB::Tiforth
+{
+
+constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
+
+constexpr uint32_t PLAN_KIND_CAST_UTF8_TO_DECIMAL = 1;
+constexpr uint32_t PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD = 2;
+constexpr uint32_t PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 6;
+constexpr uint32_t PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 10;
+
+constexpr uint32_t INPUT_ID_SCALAR = 0;
+constexpr uint32_t INPUT_ID_BUILD = 0;
+constexpr uint32_t INPUT_ID_PROBE = 1;
+
+constexpr uint32_t STATUS_KIND_OK = 0;
+constexpr uint32_t STATUS_KIND_PROTOCOL_ERROR = 5;
+constexpr uint32_t STATUS_CODE_NONE = 0;
+constexpr uint32_t STATUS_CODE_INSTANCE_FINISH_ONLY = 13;
+constexpr uint32_t STATUS_CODE_MORE_OUTPUT_AVAILABLE = 29;
+
+constexpr uint32_t PHYSICAL_TYPE_INT64 = 1;
+constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
+constexpr uint32_t PHYSICAL_TYPE_DECIMAL128 = 4;
+
+constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
+constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
+
+constexpr uint32_t AMBIENT_REQUIREMENT_SQL_MODE = 1u << 0;
+constexpr uint32_t AMBIENT_REQUIREMENT_CHARSET = 1u << 2;
+constexpr uint32_t AMBIENT_REQUIREMENT_DEFAULT_COLLATION = 1u << 3;
+
+constexpr uint32_t SQL_MODE_TRUNCATE_AS_WARNING = 2;
+constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
+constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
+
+struct TiforthExecutionBuildRequestV2
+{
+    uint32_t abi_version;
+    uint32_t plan_kind;
+    uint32_t ambient_requirement_mask;
+    uint32_t sql_mode;
+    uint32_t session_charset;
+    uint32_t default_collation;
+    bool decimal_precision_is_set;
+    uint8_t decimal_precision;
+    bool decimal_scale_is_set;
+    int8_t decimal_scale;
+    uint32_t max_block_size;
+};
+
+struct TiforthExecutionColumnViewV2
+{
+    uint32_t physical_type;
+    const uint8_t * null_bitmap;
+    uint32_t null_bitmap_bit_offset;
+    uint32_t row_offset;
+    const int64_t * values;
+    const int32_t * offsets;
+    const uint8_t * data;
+    const void * decimal128_words;
+    bool decimal_precision_is_set;
+    uint8_t decimal_precision;
+    bool decimal_scale_is_set;
+    int8_t decimal_scale;
+};
+
+struct TiforthBatchViewV2
+{
+    uint32_t abi_version;
+    uint32_t ownership_mode;
+    uint32_t column_count;
+    uint32_t row_count;
+    const TiforthExecutionColumnViewV2 * columns;
+};
+
+struct TiforthStatusV2
+{
+    uint32_t abi_version;
+    uint32_t kind;
+    uint32_t code;
+    uint32_t warning_count;
+    char message[256];
+};
+
+struct TiforthExecutionExecutableHandleV2;
+struct TiforthExecutionInstanceHandleV2;
+
+struct TiforthExecutionHostV2Api
+{
+    using BuildFn = void (*) (
+        const TiforthExecutionBuildRequestV2 *,
+        TiforthStatusV2 *,
+        TiforthExecutionExecutableHandleV2 **);
+    using OpenFn = void (*) (
+        const TiforthExecutionExecutableHandleV2 *,
+        TiforthStatusV2 *,
+        TiforthExecutionInstanceHandleV2 **);
+    using DriveInputBatchFn = void (*) (
+        TiforthExecutionInstanceHandleV2 *,
+        uint32_t,
+        const TiforthBatchViewV2 *,
+        TiforthStatusV2 *,
+        TiforthBatchViewV2 *);
+    using DriveEndOfInputFn = void (*) (TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
+    using DriveEndOfInputWithOutputFn = void (*) (
+        TiforthExecutionInstanceHandleV2 *,
+        uint32_t,
+        TiforthStatusV2 *,
+        TiforthBatchViewV2 *);
+    using ContinueOutputFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
+    using FinishFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
+    using ReleaseExecutableFn = void (*) (TiforthExecutionExecutableHandleV2 *);
+    using ReleaseInstanceFn = void (*) (TiforthExecutionInstanceHandleV2 *);
+
+    BuildFn build = nullptr;
+    OpenFn open = nullptr;
+    DriveInputBatchFn drive_input_batch = nullptr;
+    DriveEndOfInputFn drive_end_of_input = nullptr;
+    DriveEndOfInputWithOutputFn drive_end_of_input_with_output = nullptr;
+    ContinueOutputFn continue_output = nullptr;
+    FinishFn finish = nullptr;
+    ReleaseExecutableFn release_executable = nullptr;
+    ReleaseInstanceFn release_instance = nullptr;
+};
+
+std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error);
+bool requiresStrictRuntimeExecution();
+
+using Utf8Int64Row = std::pair<std::optional<String>, std::optional<int64_t>>;
+using Int64Int64Row = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
+using JoinOutputRow = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
+
+struct CastRunResult
+{
+    std::vector<std::optional<String>> output;
+    uint32_t warning_count = 0;
+};
+
+struct JoinRunResult
+{
+    std::vector<JoinOutputRow> rows;
+    uint32_t warning_count = 0;
+};
+
+CastRunResult runCastUtf8ToDecimal(
+    const TiforthExecutionHostV2Api & api,
+    const std::vector<std::optional<String>> & input,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t sql_mode,
+    uint8_t decimal_precision,
+    int8_t decimal_scale);
+
+JoinRunResult runJoinUtf8KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Utf8Int64Row> & build_rows,
+    const std::vector<Utf8Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation);
+
+JoinRunResult runJoinInt64KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Int64Int64Row> & build_rows,
+    const std::vector<Int64Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation);
+
+std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows);
+
+} // namespace DB::Tiforth

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -34,7 +34,7 @@ cmake -S . -B /tmp/tiflash-linked-host-v2 -GNinja \
 ## Build
 
 ```bash
-cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
+cmake --build /tmp/tiflash-linked-host-v2 --target gtests_tiforth_execution_host_v2
 ```
 
 ## Run strict-mode proving tests
@@ -42,6 +42,6 @@ cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
 ```bash
 TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
-  -R TestTiforthExecutionHostV2 \
+  -R TestTiforthExecutionHostV2LinkedStrict \
   --output-on-failure
 ```

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -12,296 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Functions/TiforthExecutionHostV2Adapter.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
-#include <fmt/core.h>
 #include <iostream>
-#include <optional>
-#include <string>
-#include <vector>
 
 namespace DB::tests
 {
 namespace
 {
 
-constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
-constexpr uint32_t PLAN_KIND_CAST_UTF8_TO_DECIMAL = 1;
-constexpr uint32_t INPUT_ID_SCALAR = 0;
-constexpr uint32_t SQL_MODE_TRUNCATE_AS_WARNING = 2;
-constexpr uint32_t STATUS_KIND_OK = 0;
-constexpr uint32_t STATUS_KIND_PROTOCOL_ERROR = 5;
-constexpr uint32_t STATUS_CODE_NONE = 0;
-constexpr uint32_t STATUS_CODE_INSTANCE_FINISH_ONLY = 13;
-constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
-constexpr uint32_t PHYSICAL_TYPE_DECIMAL128 = 4;
-constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
-constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_SQL_MODE = 1u << 0;
-
 constexpr const char * FUNC_NAME_TIDB_CAST = "tidb_cast";
-
-struct TiforthExecutionBuildRequestV2
-{
-    uint32_t abi_version;
-    uint32_t plan_kind;
-    uint32_t ambient_requirement_mask;
-    uint32_t sql_mode;
-    uint32_t session_charset;
-    uint32_t default_collation;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-    uint32_t max_block_size;
-};
-
-struct TiforthExecutionColumnViewV2
-{
-    uint32_t physical_type;
-    const uint8_t * null_bitmap;
-    uint32_t null_bitmap_bit_offset;
-    uint32_t row_offset;
-    const int64_t * values;
-    const int32_t * offsets;
-    const uint8_t * data;
-    const void * decimal128_words;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-};
-
-struct TiforthBatchViewV2
-{
-    uint32_t abi_version;
-    uint32_t ownership_mode;
-    uint32_t column_count;
-    uint32_t row_count;
-    const TiforthExecutionColumnViewV2 * columns;
-};
-
-struct TiforthStatusV2
-{
-    uint32_t abi_version;
-    uint32_t kind;
-    uint32_t code;
-    uint32_t warning_count;
-    char message[256];
-};
-
-struct TiforthExecutionExecutableHandleV2;
-struct TiforthExecutionInstanceHandleV2;
-
-extern "C"
-{
-void tiforth_execution_host_v2_build(
-    const TiforthExecutionBuildRequestV2 * request,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionExecutableHandleV2 ** out_executable);
-void tiforth_execution_host_v2_open(
-    const TiforthExecutionExecutableHandleV2 * executable,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionInstanceHandleV2 ** out_instance);
-void tiforth_execution_host_v2_drive_input_batch(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    const TiforthBatchViewV2 * input,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_drive_end_of_input(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_continue_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_finish(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
-void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
-}
-
-struct TiforthExecutionHostV2Api
-{
-    using BuildFn = void (*)(
-        const TiforthExecutionBuildRequestV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionExecutableHandleV2 **);
-    using OpenFn = void (*)(
-        const TiforthExecutionExecutableHandleV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionInstanceHandleV2 **);
-    using DriveInputBatchFn = void (*)(
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        const TiforthBatchViewV2 *,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using DriveEndOfInputFn = void (*)(TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
-    using ContinueOutputFn = void (*)(TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
-    using FinishFn = void (*)(TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
-    using ReleaseExecutableFn = void (*)(TiforthExecutionExecutableHandleV2 *);
-    using ReleaseInstanceFn = void (*)(TiforthExecutionInstanceHandleV2 *);
-
-    BuildFn build = nullptr;
-    OpenFn open = nullptr;
-    DriveInputBatchFn drive_input_batch = nullptr;
-    DriveEndOfInputFn drive_end_of_input = nullptr;
-    ContinueOutputFn continue_output = nullptr;
-    FinishFn finish = nullptr;
-    ReleaseExecutableFn release_executable = nullptr;
-    ReleaseInstanceFn release_instance = nullptr;
-};
-
-std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
-{
-#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
-    (void)error;
-    TiforthExecutionHostV2Api api;
-    api.build = tiforth_execution_host_v2_build;
-    api.open = tiforth_execution_host_v2_open;
-    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
-    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
-    api.continue_output = tiforth_execution_host_v2_continue_output;
-    api.finish = tiforth_execution_host_v2_finish;
-    api.release_executable = tiforth_execution_host_v2_release_executable;
-    api.release_instance = tiforth_execution_host_v2_release_instance;
-    return api;
-#else
-    error
-        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
-          "and either -DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> "
-          "or -DTIFORTH_FFI_C_LIB_DIR=/abs/path/to/libdir "
-          "(-DTIFORTH_FFI_C_LIB_NAME defaults to tiforth_ffi_c); "
-          "see dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md "
-          "to run this donor adapter test";
-    return std::nullopt;
-#endif
-}
-
-bool requiresStrictRuntimeExecution()
-{
-    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
-    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
-}
-
-bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
-{
-    if (column.null_bitmap == nullptr || row_count == 0)
-        return true;
-    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
-    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
-}
-
-String uint128ToString(unsigned __int128 value)
-{
-    if (value == 0)
-        return "0";
-
-    String digits;
-    while (value > 0)
-    {
-        const uint8_t digit = static_cast<uint8_t>(value % 10);
-        digits.push_back(static_cast<char>('0' + digit));
-        value /= 10;
-    }
-    std::reverse(digits.begin(), digits.end());
-    return digits;
-}
-
-String formatDecimal128(__int128 value, int8_t scale)
-{
-    const bool negative = value < 0;
-    unsigned __int128 abs_value;
-    if (negative)
-    {
-        // avoid overflow when value is the smallest signed 128-bit number
-        abs_value = static_cast<unsigned __int128>(-(value + 1));
-        abs_value += 1;
-    }
-    else
-    {
-        abs_value = static_cast<unsigned __int128>(value);
-    }
-
-    if (scale == 0)
-    {
-        String rendered = uint128ToString(abs_value);
-        if (negative)
-            rendered.insert(rendered.begin(), '-');
-        return rendered;
-    }
-
-    String digits = uint128ToString(abs_value);
-    const size_t scale_digits = static_cast<size_t>(scale);
-    if (digits.size() <= scale_digits)
-        digits.insert(0, scale_digits + 1 - digits.size(), '0');
-
-    const size_t split = digits.size() - scale_digits;
-    String rendered = fmt::format("{}.{}", digits.substr(0, split), digits.substr(split));
-    if (negative)
-        rendered.insert(rendered.begin(), '-');
-    return rendered;
-}
-
-struct Utf8BatchOwned
-{
-    std::vector<uint8_t> null_bitmap;
-    std::vector<int32_t> offsets;
-    String data;
-    TiforthExecutionColumnViewV2 column{};
-    TiforthBatchViewV2 batch{};
-
-    Utf8BatchOwned(const std::vector<std::optional<String>> & rows, uint32_t ownership_mode)
-    {
-        null_bitmap.assign(rows.size() == 0 ? 0 : (rows.size() + 7) / 8, 0);
-        offsets.reserve(rows.size() + 1);
-        offsets.push_back(0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].has_value())
-            {
-                null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                data.append(rows[i].value());
-            }
-            offsets.push_back(static_cast<int32_t>(data.size()));
-        }
-
-        column.physical_type = PHYSICAL_TYPE_UTF8;
-        column.null_bitmap = null_bitmap.empty() ? nullptr : null_bitmap.data();
-        column.null_bitmap_bit_offset = 0;
-        column.row_offset = 0;
-        column.values = nullptr;
-        column.offsets = offsets.data();
-        column.data = reinterpret_cast<const uint8_t *>(data.data());
-        column.decimal128_words = nullptr;
-        column.decimal_precision_is_set = false;
-        column.decimal_precision = 0;
-        column.decimal_scale_is_set = false;
-        column.decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 1;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = &column;
-    }
-};
-
-struct AdapterRunResult
-{
-    std::vector<std::optional<String>> output;
-    uint32_t warning_count = 0;
-};
 
 class ScopedDAGFlags
 {
@@ -332,129 +54,13 @@ public:
             FUNC_NAME_TIDB_CAST,
             {decimal_column, createConstColumn<String>(1, "Nullable(String)")});
     }
-
-    void runAdapterCast(
-        TiforthExecutionHostV2Api & api,
-        const std::vector<std::optional<String>> & input,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
-    {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_CAST_UTF8_TO_DECIMAL;
-        build_request.ambient_requirement_mask = AMBIENT_REQUIREMENT_SQL_MODE;
-        build_request.sql_mode = SQL_MODE_TRUNCATE_AS_WARNING;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = true;
-        build_request.decimal_precision = 10;
-        build_request.decimal_scale_is_set = true;
-        build_request.decimal_scale = 3;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.output.clear();
-        result.warning_count = 0;
-        const size_t chunk_size = std::max<size_t>(1, (input.size() + partitions - 1) / partitions);
-        std::vector<Utf8BatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        {
-            // Retainable ownership requires input buffers to stay alive until finish().
-            const size_t batch_count = input.empty() ? 0 : (input.size() + chunk_size - 1) / chunk_size;
-            retained_batches.reserve(batch_count);
-        }
-
-        for (size_t start = 0; start < input.size(); start += chunk_size)
-        {
-            const size_t end = std::min(input.size(), start + chunk_size);
-            std::vector<std::optional<String>> batch_rows(input.begin() + static_cast<ptrdiff_t>(start), input.begin() + static_cast<ptrdiff_t>(end));
-            std::optional<Utf8BatchOwned> batch;
-            const TiforthBatchViewV2 * input_batch = nullptr;
-            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            {
-                retained_batches.emplace_back(batch_rows, ownership_mode);
-                input_batch = &retained_batches.back().batch;
-            }
-            else
-            {
-                batch.emplace(batch_rows, ownership_mode);
-                input_batch = &batch->batch;
-            }
-
-            TiforthBatchViewV2 output{};
-            output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-            api.drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
-
-            ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-            result.warning_count += status.warning_count;
-
-            ASSERT_EQ(output.column_count, 1u);
-            const auto & output_column = output.columns[0];
-            ASSERT_EQ(output_column.physical_type, PHYSICAL_TYPE_DECIMAL128);
-
-            const auto * decimal_values = reinterpret_cast<const __int128 *>(output_column.decimal128_words);
-            ASSERT_NE(decimal_values, nullptr);
-            decimal_values += output_column.row_offset;
-            for (size_t row = 0; row < output.row_count; ++row)
-            {
-                if (!isValidRow(output_column, output.row_count, row))
-                {
-                    result.output.push_back(std::nullopt);
-                    continue;
-                }
-                result.output.push_back(formatDecimal128(decimal_values[row], output_column.decimal_scale));
-            }
-        }
-
-        api.drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        TiforthBatchViewV2 continued_output{};
-        continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.continue_output(instance, &status, &continued_output);
-        ASSERT_EQ(continued_output.row_count, 0u);
-        ASSERT_EQ(continued_output.column_count, 0u);
-        if (status.kind != STATUS_KIND_OK)
-        {
-            ASSERT_EQ(status.kind, STATUS_KIND_PROTOCOL_ERROR) << status.message;
-            ASSERT_EQ(status.code, STATUS_CODE_INSTANCE_FINISH_ONLY) << status.message;
-        }
-        else
-        {
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        }
-
-        api.finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        api.release_instance(instance);
-        api.release_executable(executable);
-    }
 };
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -478,12 +84,24 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     };
 
     auto donor_native = runDonorNativeCastAsString(input);
-    const auto donor_warning_count = dag_context.getWarningCount();
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
 
-    AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
+    auto parallel = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -498,9 +116,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -526,10 +144,22 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_GT(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
+    auto parallel = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -545,9 +175,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -572,12 +202,23 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningPari
 
     auto donor_native = runDonorNativeCastAsString(input);
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
-    ASSERT_EQ(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
+    auto parallel = Tiforth::runCastUtf8ToDecimal(
+        api,
+        input,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+        10,
+        3);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -15,17 +15,11 @@
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
 #include <Functions/FunctionHelpers.h>
+#include <Functions/TiforthExecutionHostV2Adapter.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <cstdlib>
-#include <fmt/core.h>
 #include <iostream>
-#include <optional>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -34,395 +28,7 @@ namespace DB::tests
 namespace
 {
 
-constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
-constexpr uint32_t PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD = 2;
-constexpr uint32_t PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 6;
-constexpr uint32_t PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 10;
-constexpr uint32_t INPUT_ID_BUILD = 0;
-constexpr uint32_t INPUT_ID_PROBE = 1;
-constexpr uint32_t STATUS_KIND_OK = 0;
-constexpr uint32_t STATUS_CODE_NONE = 0;
-constexpr uint32_t STATUS_CODE_MORE_OUTPUT_AVAILABLE = 29;
-constexpr uint32_t PHYSICAL_TYPE_INT64 = 1;
-constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
-constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
-constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_CHARSET = 1u << 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_DEFAULT_COLLATION = 1u << 3;
-constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
-constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
-
-struct TiforthExecutionBuildRequestV2
-{
-    uint32_t abi_version;
-    uint32_t plan_kind;
-    uint32_t ambient_requirement_mask;
-    uint32_t sql_mode;
-    uint32_t session_charset;
-    uint32_t default_collation;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-    uint32_t max_block_size;
-};
-
-struct TiforthExecutionColumnViewV2
-{
-    uint32_t physical_type;
-    const uint8_t * null_bitmap;
-    uint32_t null_bitmap_bit_offset;
-    uint32_t row_offset;
-    const int64_t * values;
-    const int32_t * offsets;
-    const uint8_t * data;
-    const void * decimal128_words;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-};
-
-struct TiforthBatchViewV2
-{
-    uint32_t abi_version;
-    uint32_t ownership_mode;
-    uint32_t column_count;
-    uint32_t row_count;
-    const TiforthExecutionColumnViewV2 * columns;
-};
-
-struct TiforthStatusV2
-{
-    uint32_t abi_version;
-    uint32_t kind;
-    uint32_t code;
-    uint32_t warning_count;
-    char message[256];
-};
-
-struct TiforthExecutionExecutableHandleV2;
-struct TiforthExecutionInstanceHandleV2;
-
-extern "C"
-{
-void tiforth_execution_host_v2_build(
-    const TiforthExecutionBuildRequestV2 * request,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionExecutableHandleV2 ** out_executable);
-void tiforth_execution_host_v2_open(
-    const TiforthExecutionExecutableHandleV2 * executable,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionInstanceHandleV2 ** out_instance);
-void tiforth_execution_host_v2_drive_input_batch(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    const TiforthBatchViewV2 * input,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_drive_end_of_input(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_drive_end_of_input_with_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_continue_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_finish(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
-void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
-}
-
-struct TiforthExecutionHostV2Api
-{
-    using BuildFn = void (*) (
-        const TiforthExecutionBuildRequestV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionExecutableHandleV2 **);
-    using OpenFn = void (*) (
-        const TiforthExecutionExecutableHandleV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionInstanceHandleV2 **);
-    using DriveInputBatchFn = void (*) (
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        const TiforthBatchViewV2 *,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using DriveEndOfInputFn = void (*) (TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
-    using DriveEndOfInputWithOutputFn = void (*) (
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using ContinueOutputFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
-    using FinishFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
-    using ReleaseExecutableFn = void (*) (TiforthExecutionExecutableHandleV2 *);
-    using ReleaseInstanceFn = void (*) (TiforthExecutionInstanceHandleV2 *);
-
-    BuildFn build = nullptr;
-    OpenFn open = nullptr;
-    DriveInputBatchFn drive_input_batch = nullptr;
-    DriveEndOfInputFn drive_end_of_input = nullptr;
-    DriveEndOfInputWithOutputFn drive_end_of_input_with_output = nullptr;
-    ContinueOutputFn continue_output = nullptr;
-    FinishFn finish = nullptr;
-    ReleaseExecutableFn release_executable = nullptr;
-    ReleaseInstanceFn release_instance = nullptr;
-};
-
-std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
-{
-#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
-    (void)error;
-    TiforthExecutionHostV2Api api;
-    api.build = tiforth_execution_host_v2_build;
-    api.open = tiforth_execution_host_v2_open;
-    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
-    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
-    api.drive_end_of_input_with_output = tiforth_execution_host_v2_drive_end_of_input_with_output;
-    api.continue_output = tiforth_execution_host_v2_continue_output;
-    api.finish = tiforth_execution_host_v2_finish;
-    api.release_executable = tiforth_execution_host_v2_release_executable;
-    api.release_instance = tiforth_execution_host_v2_release_instance;
-    return api;
-#else
-    error
-        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
-          "and either -DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> "
-          "or -DTIFORTH_FFI_C_LIB_DIR=/abs/path/to/libdir "
-          "(-DTIFORTH_FFI_C_LIB_NAME defaults to tiforth_ffi_c); "
-          "see dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md "
-          "to run this donor adapter test";
-    return std::nullopt;
-#endif
-}
-
-bool requiresStrictRuntimeExecution()
-{
-    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
-    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
-}
-
-bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
-{
-    if (column.null_bitmap == nullptr || row_count == 0)
-        return true;
-    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
-    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
-}
-
-using JoinInputRow = std::pair<std::optional<String>, std::optional<int64_t>>;
-using Int64JoinInputRow = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
-using JoinOutputRow = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
-
-std::vector<JoinOutputRow> canonicalizeRows(std::vector<JoinOutputRow> rows)
-{
-    const auto rank_value = [](const std::optional<int64_t> & value) {
-        return std::make_pair(value.has_value() ? 1 : 0, value.value_or(0));
-    };
-
-    std::sort(
-        rows.begin(),
-        rows.end(),
-        [&](const JoinOutputRow & lhs, const JoinOutputRow & rhs) {
-            const auto lhs_build = rank_value(lhs.first);
-            const auto rhs_build = rank_value(rhs.first);
-            if (lhs_build != rhs_build)
-                return lhs_build < rhs_build;
-            return rank_value(lhs.second) < rank_value(rhs.second);
-        });
-    return rows;
-}
-
-struct JoinBatchOwned
-{
-    std::vector<uint8_t> key_null_bitmap;
-    std::vector<int32_t> key_offsets;
-    String key_data;
-
-    std::vector<int64_t> payload_values;
-    std::vector<uint8_t> payload_null_bitmap;
-
-    TiforthExecutionColumnViewV2 columns[2]{};
-    TiforthBatchViewV2 batch{};
-
-    JoinBatchOwned(const std::vector<JoinInputRow> & rows, uint32_t ownership_mode)
-    {
-        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-        key_offsets.reserve(rows.size() + 1);
-        key_offsets.push_back(0);
-
-        payload_values.reserve(rows.size());
-        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].first.has_value())
-            {
-                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                key_data.append(rows[i].first.value());
-            }
-            key_offsets.push_back(static_cast<int32_t>(key_data.size()));
-
-            if (rows[i].second.has_value())
-            {
-                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                payload_values.push_back(rows[i].second.value());
-            }
-            else
-            {
-                payload_values.push_back(0);
-            }
-        }
-
-        columns[0].physical_type = PHYSICAL_TYPE_UTF8;
-        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
-        columns[0].null_bitmap_bit_offset = 0;
-        columns[0].row_offset = 0;
-        columns[0].values = nullptr;
-        columns[0].offsets = key_offsets.data();
-        columns[0].data = key_data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(key_data.data());
-        columns[0].decimal128_words = nullptr;
-        columns[0].decimal_precision_is_set = false;
-        columns[0].decimal_precision = 0;
-        columns[0].decimal_scale_is_set = false;
-        columns[0].decimal_scale = 0;
-
-        columns[1].physical_type = PHYSICAL_TYPE_INT64;
-        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
-        columns[1].null_bitmap_bit_offset = 0;
-        columns[1].row_offset = 0;
-        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
-        columns[1].offsets = nullptr;
-        columns[1].data = nullptr;
-        columns[1].decimal128_words = nullptr;
-        columns[1].decimal_precision_is_set = false;
-        columns[1].decimal_precision = 0;
-        columns[1].decimal_scale_is_set = false;
-        columns[1].decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 2;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = columns;
-    }
-};
-
-struct Int64JoinBatchOwned
-{
-    std::vector<int64_t> key_values;
-    std::vector<uint8_t> key_null_bitmap;
-
-    std::vector<int64_t> payload_values;
-    std::vector<uint8_t> payload_null_bitmap;
-
-    TiforthExecutionColumnViewV2 columns[2]{};
-    TiforthBatchViewV2 batch{};
-
-    Int64JoinBatchOwned(const std::vector<Int64JoinInputRow> & rows, uint32_t ownership_mode)
-    {
-        key_values.reserve(rows.size());
-        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        payload_values.reserve(rows.size());
-        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].first.has_value())
-            {
-                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                key_values.push_back(rows[i].first.value());
-            }
-            else
-            {
-                key_values.push_back(0);
-            }
-
-            if (rows[i].second.has_value())
-            {
-                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                payload_values.push_back(rows[i].second.value());
-            }
-            else
-            {
-                payload_values.push_back(0);
-            }
-        }
-
-        columns[0].physical_type = PHYSICAL_TYPE_INT64;
-        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
-        columns[0].null_bitmap_bit_offset = 0;
-        columns[0].row_offset = 0;
-        columns[0].values = key_values.empty() ? nullptr : key_values.data();
-        columns[0].offsets = nullptr;
-        columns[0].data = nullptr;
-        columns[0].decimal128_words = nullptr;
-        columns[0].decimal_precision_is_set = false;
-        columns[0].decimal_precision = 0;
-        columns[0].decimal_scale_is_set = false;
-        columns[0].decimal_scale = 0;
-
-        columns[1].physical_type = PHYSICAL_TYPE_INT64;
-        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
-        columns[1].null_bitmap_bit_offset = 0;
-        columns[1].row_offset = 0;
-        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
-        columns[1].offsets = nullptr;
-        columns[1].data = nullptr;
-        columns[1].decimal128_words = nullptr;
-        columns[1].decimal_precision_is_set = false;
-        columns[1].decimal_precision = 0;
-        columns[1].decimal_scale_is_set = false;
-        columns[1].decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 2;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = columns;
-    }
-};
-
-void appendJoinOutputRows(const TiforthBatchViewV2 & output, std::vector<JoinOutputRow> & rows)
-{
-    if (output.row_count == 0)
-        return;
-
-    ASSERT_EQ(output.column_count, 2u);
-
-    const auto & build_payload = output.columns[0];
-    const auto & probe_payload = output.columns[1];
-
-    ASSERT_EQ(build_payload.physical_type, PHYSICAL_TYPE_INT64);
-    ASSERT_EQ(probe_payload.physical_type, PHYSICAL_TYPE_INT64);
-
-    ASSERT_NE(build_payload.values, nullptr);
-    ASSERT_NE(probe_payload.values, nullptr);
-
-    const auto * build_values = build_payload.values + build_payload.row_offset;
-    const auto * probe_values = probe_payload.values + probe_payload.row_offset;
-
-    for (size_t row = 0; row < output.row_count; ++row)
-    {
-        const auto build_value = isValidRow(build_payload, output.row_count, row)
-            ? std::optional<int64_t>(build_values[row])
-            : std::nullopt;
-        const auto probe_value = isValidRow(probe_payload, output.row_count, row)
-            ? std::optional<int64_t>(probe_values[row])
-            : std::nullopt;
-        rows.emplace_back(build_value, probe_value);
-    }
-}
+using JoinOutputRow = Tiforth::JoinOutputRow;
 
 std::vector<std::optional<int64_t>> readNullableInt64Column(const ColumnWithTypeAndName & column)
 {
@@ -476,12 +82,6 @@ std::vector<JoinOutputRow> joinRowsFromColumns(const ColumnsWithTypeAndName & co
 }
 
 struct DonorRunResult
-{
-    std::vector<JoinOutputRow> rows;
-    uint32_t warning_count = 0;
-};
-
-struct AdapterRunResult
 {
     std::vector<JoinOutputRow> rows;
     uint32_t warning_count = 0;
@@ -549,7 +149,7 @@ public:
                            .build(context);
 
         DonorRunResult result;
-        result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.rows = Tiforth::canonicalizeJoinRows(joinRowsFromColumns(executeStreams(request, concurrency)));
         result.warning_count = getDAGContext().getWarningCount();
         return result;
     }
@@ -566,7 +166,7 @@ public:
                            .build(context);
 
         DonorRunResult result;
-        result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.rows = Tiforth::canonicalizeJoinRows(joinRowsFromColumns(executeStreams(request, concurrency)));
         result.warning_count = getDAGContext().getWarningCount();
         return result;
     }
@@ -583,405 +183,17 @@ public:
                            .build(context);
 
         DonorRunResult result;
-        result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.rows = Tiforth::canonicalizeJoinRows(joinRowsFromColumns(executeStreams(request, concurrency)));
         result.warning_count = getDAGContext().getWarningCount();
         return result;
-    }
-
-    void runAdapterInnerJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
-    {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask =
-            AMBIENT_REQUIREMENT_CHARSET | AMBIENT_REQUIREMENT_DEFAULT_COLLATION;
-        build_request.sql_mode = 0;
-        build_request.session_charset = SESSION_CHARSET_UTF8MB4;
-        build_request.default_collation = DEFAULT_COLLATION_UTF8MB4_BIN;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-        std::vector<JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        const std::vector<JoinInputRow> build_rows = {
-            {String("k"), 10},
-            {String("k"), 20},
-            {String("x"), 30},
-            {std::nullopt, 40},
-        };
-        const std::vector<JoinInputRow> probe_rows = {
-            {String("k"), 100},
-            {String("x"), 200},
-            {String("z"), 300},
-            {std::nullopt, 400},
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        api.finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        api.release_instance(instance);
-        api.release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
-    }
-
-    void runAdapterBuildOuterJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
-    {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask = 0;
-        build_request.sql_mode = 0;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-        std::vector<Int64JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<Int64JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<Int64JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        const std::vector<Int64JoinInputRow> build_rows = {
-            {1, 10},
-            {1, 11},
-            {5, 50},
-            {7, 70},
-        };
-        const std::vector<Int64JoinInputRow> probe_rows = {
-            {1, 100},
-            {5, 500},
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        api.finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        api.release_instance(instance);
-        api.release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
-    }
-
-    void runAdapterProbeOuterJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
-    {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask = 0;
-        build_request.sql_mode = 0;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-        std::vector<Int64JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<Int64JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<Int64JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        const std::vector<Int64JoinInputRow> build_rows = {
-            {1, 10},
-            {1, 11},
-            {5, 50},
-        };
-        const std::vector<Int64JoinInputRow> probe_rows = {
-            {1, 100},
-            {2, 200},
-            {std::nullopt, 300},
-            {5, 500},
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        api.finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        api.release_instance(instance);
-        api.release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
     }
 };
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -998,10 +210,39 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
     ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
-    AdapterRunResult adapter_serial;
-    runAdapterInnerJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
-    AdapterRunResult adapter_parallel;
-    runAdapterInnerJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    const std::vector<Tiforth::Utf8Int64Row> build_rows = {
+        {String("k"), 10},
+        {String("k"), 20},
+        {String("x"), 30},
+        {std::nullopt, 40},
+    };
+    const std::vector<Tiforth::Utf8Int64Row> probe_rows = {
+        {String("k"), 100},
+        {String("x"), 200},
+        {String("z"), 300},
+        {std::nullopt, 400},
+    };
+
+    auto adapter_serial = Tiforth::runJoinUtf8KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        Tiforth::AMBIENT_REQUIREMENT_CHARSET | Tiforth::AMBIENT_REQUIREMENT_DEFAULT_COLLATION,
+        Tiforth::SESSION_CHARSET_UTF8MB4,
+        Tiforth::DEFAULT_COLLATION_UTF8MB4_BIN);
+    auto adapter_parallel = Tiforth::runJoinUtf8KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        Tiforth::AMBIENT_REQUIREMENT_CHARSET | Tiforth::AMBIENT_REQUIREMENT_DEFAULT_COLLATION,
+        Tiforth::SESSION_CHARSET_UTF8MB4,
+        Tiforth::DEFAULT_COLLATION_UTF8MB4_BIN);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
@@ -1017,9 +258,9 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -1036,10 +277,37 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
     ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
-    AdapterRunResult adapter_serial;
-    runAdapterBuildOuterJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
-    AdapterRunResult adapter_parallel;
-    runAdapterBuildOuterJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    const std::vector<Tiforth::Int64Int64Row> build_rows = {
+        {1, 10},
+        {1, 11},
+        {5, 50},
+        {7, 70},
+    };
+    const std::vector<Tiforth::Int64Int64Row> probe_rows = {
+        {1, 100},
+        {5, 500},
+    };
+
+    auto adapter_serial = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        0,
+        0,
+        0);
+    auto adapter_parallel = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        0,
+        0,
+        0);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
@@ -1055,9 +323,9 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
     if (!maybe_api.has_value())
     {
         if (strict_runtime_execution)
@@ -1074,10 +342,38 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
     ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
-    AdapterRunResult adapter_serial;
-    runAdapterProbeOuterJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
-    AdapterRunResult adapter_parallel;
-    runAdapterProbeOuterJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    const std::vector<Tiforth::Int64Int64Row> build_rows = {
+        {1, 10},
+        {1, 11},
+        {5, 50},
+    };
+    const std::vector<Tiforth::Int64Int64Row> probe_rows = {
+        {1, 100},
+        {2, 200},
+        {std::nullopt, 300},
+        {5, 500},
+    };
+
+    auto adapter_serial = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        1,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        0,
+        0,
+        0);
+    auto adapter_parallel = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        2,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        0,
+        0,
+        0);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -124,10 +124,24 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "build_outer_empty_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("probe_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
              toNullableVec<Int64>("build_payload", {10, 11, 50})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_empty_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("build_payload", std::vector<std::optional<Int64>>{})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -171,12 +185,46 @@ public:
         return result;
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinWithEmptyProbe(size_t concurrency)
+    {
+        getDAGContext().clearWarnings();
+        auto request = context.scan("tiforth_host_v2", "build_outer_empty_probe_input")
+                           .join(
+                               context.scan("tiforth_host_v2", "build_outer_build_input"),
+                               tipb::JoinType::TypeRightOuterJoin,
+                               {col("join_key")})
+                           .project({"build_payload", "probe_payload"})
+                           .build(context);
+
+        DonorRunResult result;
+        result.rows = Tiforth::canonicalizeJoinRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.warning_count = getDAGContext().getWarningCount();
+        return result;
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoin(size_t concurrency)
     {
         getDAGContext().clearWarnings();
         auto request = context.scan("tiforth_host_v2", "probe_outer_probe_input")
                            .join(
                                context.scan("tiforth_host_v2", "probe_outer_build_input"),
+                               tipb::JoinType::TypeLeftOuterJoin,
+                               {col("join_key")})
+                           .project({"build_payload", "probe_payload"})
+                           .build(context);
+
+        DonorRunResult result;
+        result.rows = Tiforth::canonicalizeJoinRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.warning_count = getDAGContext().getWarningCount();
+        return result;
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinWithEmptyBuild(size_t concurrency)
+    {
+        getDAGContext().clearWarnings();
+        auto request = context.scan("tiforth_host_v2", "probe_outer_probe_input")
+                           .join(
+                               context.scan("tiforth_host_v2", "probe_outer_empty_build_input"),
                                tipb::JoinType::TypeLeftOuterJoin,
                                {col("join_key")})
                            .project({"build_payload", "probe_payload"})
@@ -321,6 +369,79 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadParityEmptyProbeLegacyBuildAndProbeEndSplitOutputHighPartitionRetainable)
+{
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+
+    auto donor_serial = runDonorNativeBuildOuterJoinWithEmptyProbe(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinWithEmptyProbe(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    const std::vector<Tiforth::Int64Int64Row> build_rows = {
+        {1, 10},
+        {1, 11},
+        {5, 50},
+        {7, 70},
+    };
+    const std::vector<Tiforth::Int64Int64Row> probe_rows = {};
+
+    auto adapter_serial_many_partitions = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        8,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        0,
+        0,
+        0,
+        1,
+        false,
+        false);
+    auto adapter_parallel_many_partitions = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        8,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        0,
+        0,
+        0,
+        1,
+        false,
+        false);
+
+    ASSERT_EQ(adapter_serial_many_partitions.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel_many_partitions.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial_many_partitions.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel_many_partitions.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-build-outer-join-empty-probe-legacy-end-partitions] serial=8 warnings="
+              << adapter_serial_many_partitions.warning_count
+              << " rows=" << adapter_serial_many_partitions.rows.size() << " parallel=8 warnings="
+              << adapter_parallel_many_partitions.warning_count
+              << " rows=" << adapter_parallel_many_partitions.rows.size()
+              << " donor_warnings=" << donor_serial.warning_count << " donor_rows=" << donor_serial.rows.size()
+              << " legacy_build_end=1 legacy_probe_end=1 max_block_size=1 parity=ok" << std::endl;
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
     const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
@@ -385,6 +506,79 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
               << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadParityEmptyBuildLegacyBuildAndProbeEndSplitOutputHighPartitionRetainable)
+{
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+
+    auto donor_serial = runDonorNativeProbeOuterJoinWithEmptyBuild(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinWithEmptyBuild(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    const std::vector<Tiforth::Int64Int64Row> build_rows = {};
+    const std::vector<Tiforth::Int64Int64Row> probe_rows = {
+        {1, 100},
+        {2, 200},
+        {std::nullopt, 300},
+        {5, 500},
+    };
+
+    auto adapter_serial_many_partitions = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        8,
+        Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        0,
+        0,
+        0,
+        1,
+        false,
+        false);
+    auto adapter_parallel_many_partitions = Tiforth::runJoinInt64KeyInt64Payload(
+        api,
+        Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        build_rows,
+        probe_rows,
+        8,
+        Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        0,
+        0,
+        0,
+        1,
+        false,
+        false);
+
+    ASSERT_EQ(adapter_serial_many_partitions.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel_many_partitions.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial_many_partitions.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel_many_partitions.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-probe-outer-join-empty-build-legacy-end-partitions] serial=8 warnings="
+              << adapter_serial_many_partitions.warning_count
+              << " rows=" << adapter_serial_many_partitions.rows.size() << " parallel=8 warnings="
+              << adapter_parallel_many_partitions.warning_count
+              << " rows=" << adapter_parallel_many_partitions.rows.size()
+              << " donor_warnings=" << donor_serial.warning_count << " donor_rows=" << donor_serial.rows.size()
+              << " legacy_build_end=1 legacy_probe_end=1 max_block_size=1 parity=ok" << std::endl;
 }
 
 } // namespace


### PR DESCRIPTION
Role: Coder-R195

## Summary
- add reusable donor-side adapter module `dbms/src/Functions/TiforthExecutionHostV2Adapter.{h,cpp}` for host-v2 execution flow
- route donor-native CAST and hash-join host-v2 gtests through that production-side adapter module instead of fixture-local duplicated host wiring
- keep donor-native serial + parallel proving coverage at test entry points while moving execution wiring into reusable code

## Required mapping (test entry -> adapter path -> host-v2 path)
- `dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp`
  - `DB::Tiforth::runCastUtf8ToDecimal`
  - linked `tiforth_execution_host_v2_*` API from `loadExecutionHostV2Api`
- `dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp`
  - `DB::Tiforth::runJoinUtf8KeyInt64Payload` / `DB::Tiforth::runJoinInt64KeyInt64Payload`
  - linked `tiforth_execution_host_v2_*` API from `loadExecutionHostV2Api`

## Validation
- `cargo build -p tiforth-ffi-c` in `/Users/zanmato/dev/tiforth-worktrees/tiforth-issue-252-r195-20260409-032820`
- linked donor configure succeeded:
  - `cmake -S . -B cmake-build-r195 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-issue-252-r195-20260409-032820/target/debug/libtiforth_ffi_c.dylib`
- targeted donor compile succeeded for changed adapter and donor-native test entries:
  - `cmake --build cmake-build-r195 --target dbms/src/Functions/CMakeFiles/tiflash_functions.dir/TiforthExecutionHostV2Adapter.cpp.o dbms/CMakeFiles/gtests_dbms.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp.o dbms/CMakeFiles/gtests_dbms.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp.o -j8`
- note: full `gtests_dbms` link/run was started but intentionally not completed in this round because it fans out to a full donor build graph; this round’s executable evidence is the linked configure + changed-target object builds above.

## Issue
Refs zanmato1984/tiforth#252
Refs zanmato1984/tiforth#77
