### PR TITLE
Role: Coder-R244: add linked legacy-end inner-join parity slice for Gate D #252

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1464,6 +1464,50 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityHighPa
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoin(1);
+    auto donor_parallel = runDonorNativeInnerJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-inner-join-high-partition-legacy-end] serial=8 warnings="
+              << adapter_serial.warning_count << " rows=" << adapter_serial.rows.size()
+              << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 end_with_output=0 parity=ok"
+              << std::endl;
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockSerialAndParallel)
 {
     auto donor_serial = runDonorNativeInnerJoinFanout(1);


### PR DESCRIPTION
Role: Coder-R244

## Summary
- re-based this PR branch onto current `tiforth` head so the open donor PR is conflict-free and reviewable again
- added one focused executable donor-native parity slice on reusable adapter path:
  - `InnerHashJoinPayloadParityHighPartitionMaxBlockLegacyEndSerialAndParallel`
- the new case keeps donor-native mapping explicit while exercising legacy end-of-input under high partition pressure with split output settings (`max_block_size=1`)

## Mapping
- test entry:
  - `dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp`
- adapter path:
  - `dbms/src/Functions/TiforthExecutionHostV2Adapter.{h,cpp}` via `runJoinUtf8KeyInt64Payload` (through `runAdapterInnerJoin`)
- linked host-v2 path:
  - `tiforth_execution_host_v2_drive_input_batch`
  - `tiforth_execution_host_v2_drive_end_of_input` (legacy end)
  - `tiforth_execution_host_v2_continue_output`

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo build -p tiforth-ffi-c` in `/Users/zanmato/dev/tiforth-worktrees/tiforth-main-r244-20260411-131805`
- `cmake -S . -B /tmp/tiflash-r244-pr22-linked-host-v2 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-main-r244-20260411-131805/target/debug/libtiforth_ffi_c.dylib`
- `cmake --build /tmp/tiflash-r244-pr22-linked-host-v2 --target dbms/CMakeFiles/gtests_tiforth_execution_host_v2.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp.o -j4`
- `ctest --test-dir /tmp/tiflash-r244-pr22-linked-host-v2 -N -R TestTiforthExecutionHostV2LinkedStrict`

## Issue
Refs zanmato1984/tiforth#252
Refs zanmato1984/tiforth#77
