### PR TITLE
Role: Coder-R203: add focused malformed multi-dot donor cast parity slice for Gate D #251

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -360,14 +360,14 @@ if (ENABLE_TESTS)
         ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
         ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp)
 
-    # attach all dbms gtest sources
+    # Attach all dbms gtest sources except host-v2 proving files.
+    # Those proving files are built only via the dedicated linked target below
+    # to avoid duplicate compilation and mixed-path execution.
     grep_gtest_sources(${TiFlash_SOURCE_DIR}/dbms dbms_gtest_sources)
-    if (NOT ENABLE_TIFORTH_HOST_V2_LINKED_TESTS)
-        list(
-            FILTER dbms_gtest_sources
-            EXCLUDE
-            REGEX "^src/Functions/tests/gtest_tiforth_execution_host_v2_.*\\.cpp$")
-    endif ()
+    list(
+        FILTER dbms_gtest_sources
+        EXCLUDE
+        REGEX "^src/Functions/tests/gtest_tiforth_execution_host_v2_.*\\.cpp$")
     add_executable(gtests_dbms EXCLUDE_FROM_ALL
         ${dbms_gtest_sources}
         ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
@@ -486,8 +486,6 @@ if (ENABLE_TESTS)
             endif ()
         endforeach ()
 
-        target_compile_definitions(gtests_dbms PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
-        target_link_libraries(gtests_dbms "${_tiforth_ffi_c_link_target}")
         add_executable(gtests_tiforth_execution_host_v2 EXCLUDE_FROM_ALL
             ${_tiforth_host_v2_gtest_sources}
             ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
@@ -510,8 +508,8 @@ if (ENABLE_TESTS)
         add_target_pch("pch-dbms.h" gtests_tiforth_execution_host_v2)
         message(
             STATUS
-                "TiForth host-v2 linked donor adapter tests: gtests_dbms and "
-                "gtests_tiforth_execution_host_v2 link ${_tiforth_ffi_c_link_target}")
+                "TiForth host-v2 linked donor adapter tests: "
+                "gtests_tiforth_execution_host_v2 links ${_tiforth_ffi_c_link_target}")
         message(
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
@@ -532,8 +530,6 @@ if (ENABLE_TESTS)
             PROPERTIES
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
-            set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
-            set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
         endif ()

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -356,6 +356,9 @@ if (ENABLE_TESTS)
         "tiforth_ffi_c"
         CACHE STRING
               "Library name used with TIFORTH_FFI_C_LIB_DIR for TiForth host-v2 linked donor adapter gtests")
+    set(_tiforth_host_v2_gtest_sources
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+        ${TiFlash_SOURCE_DIR}/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp)
 
     # attach all dbms gtest sources
     grep_gtest_sources(${TiFlash_SOURCE_DIR}/dbms dbms_gtest_sources)
@@ -485,9 +488,30 @@ if (ENABLE_TESTS)
 
         target_compile_definitions(gtests_dbms PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
         target_link_libraries(gtests_dbms "${_tiforth_ffi_c_link_target}")
+        add_executable(gtests_tiforth_execution_host_v2 EXCLUDE_FROM_ALL
+            ${_tiforth_host_v2_gtest_sources}
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/StorageConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/UserConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/Server/RaftConfigParser.cpp
+            ${TiFlash_SOURCE_DIR}/dbms/src/AggregateFunctions/AggregateFunctionSum.cpp
+        )
+        target_include_directories(gtests_tiforth_execution_host_v2 BEFORE PRIVATE ${SPARCEHASH_INCLUDE_DIR})
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PUBLIC DBMS_PUBLIC_GTEST)
+        target_compile_definitions(gtests_tiforth_execution_host_v2 PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
+        target_link_libraries(
+            gtests_tiforth_execution_host_v2
+            test_util_gtest_main
+            tiflash_functions
+            tiflash-dttool-lib
+            delta_merge
+            kvstore
+            "${_tiforth_ffi_c_link_target}")
+        target_compile_options(gtests_tiforth_execution_host_v2 PRIVATE -Wno-unknown-pragmas -Wno-deprecated-copy)
+        add_target_pch("pch-dbms.h" gtests_tiforth_execution_host_v2)
         message(
             STATUS
-                "TiForth host-v2 linked donor adapter tests: gtests_dbms links ${_tiforth_ffi_c_link_target}")
+                "TiForth host-v2 linked donor adapter tests: gtests_dbms and "
+                "gtests_tiforth_execution_host_v2 link ${_tiforth_ffi_c_link_target}")
         message(
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
@@ -499,16 +523,19 @@ if (ENABLE_TESTS)
                 "./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh")
         add_test(
             NAME TestTiforthExecutionHostV2LinkedStrict
-            COMMAND $<TARGET_FILE:gtests_dbms>
-                --gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*)
+            COMMAND
+                "${CMAKE_COMMAND}" -E env TIFORTH_REQUIRE_RUNTIME_EXECUTION=1
+                "$<TARGET_FILE:gtests_tiforth_execution_host_v2>"
+                "--gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*")
         set_tests_properties(
             TestTiforthExecutionHostV2LinkedStrict
             PROPERTIES
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                ENVIRONMENT "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1")
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
             set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
+            set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
+            set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")
         endif ()
     endif ()
 
@@ -547,6 +574,10 @@ if (ENABLE_TESTS)
 
     set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
     set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    if (TARGET gtests_tiforth_execution_host_v2)
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY BUILD_RPATH "$ORIGIN/")
+        set_property(TARGET gtests_tiforth_execution_host_v2 APPEND PROPERTY INSTALL_RPATH "$ORIGIN/")
+    endif ()
 
     if (ENABLE_CLARA)
         install (SCRIPT ${TiFlash_SOURCE_DIR}/libs/libclara-cmake/linux_post_install.cmake COMPONENT tiflash-gtest)

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -492,7 +492,20 @@ if (ENABLE_TESTS)
             STATUS
                 "TiForth host-v2 linked donor adapter strict run: "
                 "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 ctest --test-dir ${CMAKE_BINARY_DIR} "
-                "-R TestTiforthExecutionHostV2 --output-on-failure")
+                "-R TestTiforthExecutionHostV2LinkedStrict --output-on-failure")
+        message(
+            STATUS
+                "TiForth host-v2 linked donor adapter bootstrap: "
+                "./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh")
+        add_test(
+            NAME TestTiforthExecutionHostV2LinkedStrict
+            COMMAND $<TARGET_FILE:gtests_dbms>
+                --gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*)
+        set_tests_properties(
+            TestTiforthExecutionHostV2LinkedStrict
+            PROPERTIES
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                ENVIRONMENT "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1")
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")
             set_property(TARGET gtests_dbms APPEND PROPERTY BUILD_RPATH "${_tiforth_ffi_c_rpath_dir}")
             set_property(TARGET gtests_dbms APPEND PROPERTY INSTALL_RPATH "${_tiforth_ffi_c_rpath_dir}")

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -462,8 +462,14 @@ if (ENABLE_TESTS)
             tiforth_execution_host_v2_finish
             tiforth_execution_host_v2_release_executable
             tiforth_execution_host_v2_release_instance)
+        set(_tiforth_nm_args -g)
+        if (APPLE)
+            list(APPEND _tiforth_nm_args -U)
+        else ()
+            list(APPEND _tiforth_nm_args --defined-only)
+        endif ()
         execute_process(
-            COMMAND "${CMAKE_NM}" -g "${_tiforth_ffi_c_link_target}"
+            COMMAND "${CMAKE_NM}" ${_tiforth_nm_args} "${_tiforth_ffi_c_link_target}"
             RESULT_VARIABLE _tiforth_nm_result
             OUTPUT_VARIABLE _tiforth_nm_output
             ERROR_VARIABLE _tiforth_nm_error)
@@ -481,7 +487,7 @@ if (ENABLE_TESTS)
             if ("${_tiforth_symbol_match}" STREQUAL "")
                 message(
                     FATAL_ERROR
-                        "${_tiforth_ffi_c_link_target} is missing required host-v2 symbol `${_tiforth_symbol}`; "
+                        "${_tiforth_ffi_c_link_target} is missing required defined host-v2 symbol `${_tiforth_symbol}`; "
                         "choose a libtiforth_ffi_c build that exports host-v2 entrypoints.")
             endif ()
         endforeach ()

--- a/dbms/src/DataTypes/DataTypeString.cpp
+++ b/dbms/src/DataTypes/DataTypeString.cpp
@@ -351,9 +351,6 @@ PaddedPODArray<Offset> offsetToStrSize(
     PaddedPODArray<Offset> str_sizes(end - begin);
     auto chars_offsets_pos = chars_offsets.begin() + begin;
 
-    // clang-format off
-    #pragma clang loop vectorize(enable)
-    // clang-format on
     for (ssize_t i = 0; i < static_cast<ssize_t>(str_sizes.size()); ++i)
     {
         str_sizes[i] = chars_offsets_pos[i] - chars_offsets_pos[i - 1];

--- a/dbms/src/Functions/CMakeLists.txt
+++ b/dbms/src/Functions/CMakeLists.txt
@@ -32,6 +32,10 @@ add_library(tiflash_functions ${tiflash_functions_sources})
 
 target_link_libraries(tiflash_functions PUBLIC dbms PRIVATE ${FARMHASH_LIBRARIES} ${METROHASH_LIBRARIES})
 
+if (ENABLE_TIFORTH_HOST_V2_LINKED_TESTS)
+    target_compile_definitions(tiflash_functions PRIVATE TIFORTH_HOST_V2_LINKED_TESTS=1)
+endif ()
+
 target_include_directories (tiflash_functions BEFORE PUBLIC ${TiFlash_SOURCE_DIR}/contrib/libfarmhash)
 target_include_directories (tiflash_functions BEFORE PUBLIC ${TiFlash_SOURCE_DIR}/contrib/libmetrohash/src)
 target_include_directories (tiflash_functions BEFORE PUBLIC ${DIVIDE_INCLUDE_DIR})

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -632,11 +632,12 @@ CastRunResult runCastUtf8ToDecimal(
     return result;
 }
 
-JoinRunResult runJoinUtf8KeyInt64Payload(
+template <typename Row, typename BatchOwned>
+JoinRunResult runJoinKeyInt64Payload(
     const TiforthExecutionHostV2Api & api,
     uint32_t plan_kind,
-    const std::vector<Utf8Int64Row> & build_rows,
-    const std::vector<Utf8Int64Row> & probe_rows,
+    const std::vector<Row> & build_rows,
+    const std::vector<Row> & probe_rows,
     size_t partitions,
     uint32_t ownership_mode,
     uint32_t ambient_requirement_mask,
@@ -664,21 +665,21 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
 
     JoinRunResult result;
     const size_t partition_count = std::max<size_t>(1, partitions);
-    std::vector<Utf8Int64JoinBatchOwned> retained_batches;
+    std::vector<BatchOwned> retained_batches;
     if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
         retained_batches.reserve(8);
 
-    auto drive_input_rows = [&](const std::vector<Utf8Int64Row> & rows, uint32_t input_id) {
+    auto drive_input_rows = [&](const std::vector<Row> & rows, uint32_t input_id) {
         const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
         for (size_t start = 0; start < rows.size(); start += chunk_size)
         {
             const size_t end = std::min(rows.size(), start + chunk_size);
-            std::vector<Utf8Int64Row> chunk(
+            std::vector<Row> chunk(
                 rows.begin() + static_cast<ptrdiff_t>(start),
                 rows.begin() + static_cast<ptrdiff_t>(end));
 
             const TiforthBatchViewV2 * input_batch = nullptr;
-            std::optional<Utf8Int64JoinBatchOwned> borrowed_batch;
+            std::optional<BatchOwned> borrowed_batch;
             if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
             {
                 retained_batches.emplace_back(chunk, ownership_mode);
@@ -748,6 +749,35 @@ JoinRunResult runJoinUtf8KeyInt64Payload(
     return result;
 }
 
+JoinRunResult runJoinUtf8KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Utf8Int64Row> & build_rows,
+    const std::vector<Utf8Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation,
+    uint32_t max_block_size,
+    bool build_end_with_output,
+    bool probe_end_with_output)
+{
+    return runJoinKeyInt64Payload<Utf8Int64Row, Utf8Int64JoinBatchOwned>(
+        api,
+        plan_kind,
+        build_rows,
+        probe_rows,
+        partitions,
+        ownership_mode,
+        ambient_requirement_mask,
+        session_charset,
+        default_collation,
+        max_block_size,
+        build_end_with_output,
+        probe_end_with_output);
+}
+
 JoinRunResult runJoinInt64KeyInt64Payload(
     const TiforthExecutionHostV2Api & api,
     uint32_t plan_kind,
@@ -762,106 +792,19 @@ JoinRunResult runJoinInt64KeyInt64Payload(
     bool build_end_with_output,
     bool probe_end_with_output)
 {
-    TiforthExecutionBuildRequestV2 build_request{};
-    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-    build_request.plan_kind = plan_kind;
-    build_request.ambient_requirement_mask = ambient_requirement_mask;
-    build_request.sql_mode = 0;
-    build_request.session_charset = session_charset;
-    build_request.default_collation = default_collation;
-    build_request.decimal_precision_is_set = false;
-    build_request.decimal_precision = 0;
-    build_request.decimal_scale_is_set = false;
-    build_request.decimal_scale = 0;
-    build_request.max_block_size = max_block_size;
-
-    ExecutionHandles handles(api);
-    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
-
-    JoinRunResult result;
-    const size_t partition_count = std::max<size_t>(1, partitions);
-    std::vector<Int64Int64JoinBatchOwned> retained_batches;
-    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        retained_batches.reserve(8);
-
-    auto drive_input_rows = [&](const std::vector<Int64Int64Row> & rows, uint32_t input_id) {
-        const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
-        for (size_t start = 0; start < rows.size(); start += chunk_size)
-        {
-            const size_t end = std::min(rows.size(), start + chunk_size);
-            std::vector<Int64Int64Row> chunk(
-                rows.begin() + static_cast<ptrdiff_t>(start),
-                rows.begin() + static_cast<ptrdiff_t>(end));
-
-            const TiforthBatchViewV2 * input_batch = nullptr;
-            std::optional<Int64Int64JoinBatchOwned> borrowed_batch;
-            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            {
-                retained_batches.emplace_back(chunk, ownership_mode);
-                input_batch = &retained_batches.back().batch;
-            }
-            else
-            {
-                borrowed_batch.emplace(chunk, ownership_mode);
-                input_batch = &borrowed_batch->batch;
-            }
-
-            auto status = makeStatus();
-            auto output = makeBatch();
-            api.drive_input_batch(instance, input_id, input_batch, &status, &output);
-            ensureStatusKindOk("drive_input_batch", status);
-            result.warning_count += status.warning_count;
-            appendJoinOutputRows(output, result.rows);
-            drainJoinOutput(api, instance, status, result);
-        }
-    };
-
-    drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-    auto status = makeStatus();
-    if (build_end_with_output)
-    {
-        auto output = makeBatch();
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
-        ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(output, result.rows);
-        drainJoinOutput(api, instance, status, result);
-    }
-    else
-    {
-        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
-        ensureStatusKindOk("drive_end_of_input(build)", status);
-        result.warning_count += status.warning_count;
-        drainJoinOutput(api, instance, status, result);
-    }
-
-    drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-    status = makeStatus();
-    if (probe_end_with_output)
-    {
-        auto output = makeBatch();
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
-        ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(output, result.rows);
-        drainJoinOutput(api, instance, status, result);
-    }
-    else
-    {
-        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
-        ensureStatusKindOk("drive_end_of_input(probe)", status);
-        result.warning_count += status.warning_count;
-        drainJoinOutput(api, instance, status, result);
-    }
-
-    status = makeStatus();
-    api.finish(instance, &status);
-    ensureStatusOk("finish", status);
-
-    result.rows = canonicalizeJoinRows(std::move(result.rows));
-    return result;
+    return runJoinKeyInt64Payload<Int64Int64Row, Int64Int64JoinBatchOwned>(
+        api,
+        plan_kind,
+        build_rows,
+        probe_rows,
+        partitions,
+        ownership_mode,
+        ambient_requirement_mask,
+        session_charset,
+        default_collation,
+        max_block_size,
+        build_end_with_output,
+        probe_end_with_output);
 }
 
 std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows)

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -1,0 +1,886 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Functions/TiforthExecutionHostV2Adapter.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <fmt/core.h>
+#include <stdexcept>
+#include <utility>
+
+namespace DB::Tiforth
+{
+namespace
+{
+
+extern "C"
+{
+void tiforth_execution_host_v2_build(
+    const TiforthExecutionBuildRequestV2 * request,
+    TiforthStatusV2 * out_status,
+    TiforthExecutionExecutableHandleV2 ** out_executable);
+void tiforth_execution_host_v2_open(
+    const TiforthExecutionExecutableHandleV2 * executable,
+    TiforthStatusV2 * out_status,
+    TiforthExecutionInstanceHandleV2 ** out_instance);
+void tiforth_execution_host_v2_drive_input_batch(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    const TiforthBatchViewV2 * input,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_drive_end_of_input(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    TiforthStatusV2 * out_status);
+void tiforth_execution_host_v2_drive_end_of_input_with_output(
+    TiforthExecutionInstanceHandleV2 * instance,
+    uint32_t input_id,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_continue_output(
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 * out_status,
+    TiforthBatchViewV2 * out_output);
+void tiforth_execution_host_v2_finish(
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 * out_status);
+void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
+void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
+}
+
+String statusMessage(const TiforthStatusV2 & status)
+{
+    const size_t msg_len = strnlen(status.message, sizeof(status.message));
+    return String(status.message, msg_len);
+}
+
+[[noreturn]] void throwStatusError(const char * step, const TiforthStatusV2 & status)
+{
+    throw std::runtime_error(
+        fmt::format(
+            "{} failed: kind={} code={} warning_count={} message={}",
+            step,
+            status.kind,
+            status.code,
+            status.warning_count,
+            statusMessage(status)));
+}
+
+void ensureStatusKindOk(const char * step, const TiforthStatusV2 & status)
+{
+    if (status.kind != STATUS_KIND_OK)
+        throwStatusError(step, status);
+}
+
+void ensureStatusOk(const char * step, const TiforthStatusV2 & status)
+{
+    ensureStatusKindOk(step, status);
+    if (status.code != STATUS_CODE_NONE)
+        throwStatusError(step, status);
+}
+
+TiforthStatusV2 makeStatus()
+{
+    TiforthStatusV2 status{};
+    status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    return status;
+}
+
+TiforthBatchViewV2 makeBatch()
+{
+    TiforthBatchViewV2 batch{};
+    batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    return batch;
+}
+
+bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
+{
+    if (column.null_bitmap == nullptr || row_count == 0)
+        return true;
+    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
+    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
+}
+
+String uint128ToString(unsigned __int128 value)
+{
+    if (value == 0)
+        return "0";
+
+    String digits;
+    while (value > 0)
+    {
+        const uint8_t digit = static_cast<uint8_t>(value % 10);
+        digits.push_back(static_cast<char>('0' + digit));
+        value /= 10;
+    }
+    std::reverse(digits.begin(), digits.end());
+    return digits;
+}
+
+String formatDecimal128(__int128 value, int8_t scale)
+{
+    const bool negative = value < 0;
+    unsigned __int128 abs_value;
+    if (negative)
+    {
+        // avoid overflow when value is the smallest signed 128-bit number
+        abs_value = static_cast<unsigned __int128>(-(value + 1));
+        abs_value += 1;
+    }
+    else
+    {
+        abs_value = static_cast<unsigned __int128>(value);
+    }
+
+    if (scale == 0)
+    {
+        String rendered = uint128ToString(abs_value);
+        if (negative)
+            rendered.insert(rendered.begin(), '-');
+        return rendered;
+    }
+
+    String digits = uint128ToString(abs_value);
+    const size_t scale_digits = static_cast<size_t>(scale);
+    if (digits.size() <= scale_digits)
+        digits.insert(0, scale_digits + 1 - digits.size(), '0');
+
+    const size_t split = digits.size() - scale_digits;
+    String rendered = fmt::format("{}.{}", digits.substr(0, split), digits.substr(split));
+    if (negative)
+        rendered.insert(rendered.begin(), '-');
+    return rendered;
+}
+
+void appendCastOutputRows(const TiforthBatchViewV2 & output, std::vector<std::optional<String>> & rows)
+{
+    if (output.row_count == 0)
+        return;
+
+    if (output.column_count != 1)
+    {
+        throw std::runtime_error(
+            fmt::format("cast output has {} columns, expected 1", output.column_count));
+    }
+    if (output.columns == nullptr)
+        throw std::runtime_error("cast output columns is null");
+
+    const auto & output_column = output.columns[0];
+    if (output_column.physical_type != PHYSICAL_TYPE_DECIMAL128)
+    {
+        throw std::runtime_error(
+            fmt::format(
+                "cast output physical_type={}, expected decimal128",
+                output_column.physical_type));
+    }
+
+    const auto * decimal_values = reinterpret_cast<const __int128 *>(output_column.decimal128_words);
+    if (decimal_values == nullptr)
+        throw std::runtime_error("cast output decimal128_words is null");
+
+    decimal_values += output_column.row_offset;
+    for (size_t row = 0; row < output.row_count; ++row)
+    {
+        if (!isValidRow(output_column, output.row_count, row))
+        {
+            rows.push_back(std::nullopt);
+            continue;
+        }
+        rows.push_back(formatDecimal128(decimal_values[row], output_column.decimal_scale));
+    }
+}
+
+void appendJoinOutputRows(const TiforthBatchViewV2 & output, std::vector<JoinOutputRow> & rows)
+{
+    if (output.row_count == 0)
+        return;
+
+    if (output.column_count != 2)
+    {
+        throw std::runtime_error(
+            fmt::format("join output has {} columns, expected 2", output.column_count));
+    }
+    if (output.columns == nullptr)
+        throw std::runtime_error("join output columns is null");
+
+    const auto & build_payload = output.columns[0];
+    const auto & probe_payload = output.columns[1];
+
+    if (build_payload.physical_type != PHYSICAL_TYPE_INT64 || probe_payload.physical_type != PHYSICAL_TYPE_INT64)
+    {
+        throw std::runtime_error(
+            fmt::format(
+                "join output physical types are [{}, {}], expected [int64, int64]",
+                build_payload.physical_type,
+                probe_payload.physical_type));
+    }
+
+    if (build_payload.values == nullptr || probe_payload.values == nullptr)
+        throw std::runtime_error("join output value pointer is null");
+
+    const auto * build_values = build_payload.values + build_payload.row_offset;
+    const auto * probe_values = probe_payload.values + probe_payload.row_offset;
+
+    for (size_t row = 0; row < output.row_count; ++row)
+    {
+        const auto build_value = isValidRow(build_payload, output.row_count, row)
+            ? std::optional<int64_t>(build_values[row])
+            : std::nullopt;
+        const auto probe_value = isValidRow(probe_payload, output.row_count, row)
+            ? std::optional<int64_t>(probe_values[row])
+            : std::nullopt;
+        rows.emplace_back(build_value, probe_value);
+    }
+}
+
+struct Utf8BatchOwned
+{
+    std::vector<uint8_t> null_bitmap;
+    std::vector<int32_t> offsets;
+    String data;
+    TiforthExecutionColumnViewV2 column{};
+    TiforthBatchViewV2 batch{};
+
+    Utf8BatchOwned(const std::vector<std::optional<String>> & rows, uint32_t ownership_mode)
+    {
+        null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+        offsets.reserve(rows.size() + 1);
+        offsets.push_back(0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].has_value())
+            {
+                null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                data.append(rows[i].value());
+            }
+            offsets.push_back(static_cast<int32_t>(data.size()));
+        }
+
+        column.physical_type = PHYSICAL_TYPE_UTF8;
+        column.null_bitmap = null_bitmap.empty() ? nullptr : null_bitmap.data();
+        column.null_bitmap_bit_offset = 0;
+        column.row_offset = 0;
+        column.values = nullptr;
+        column.offsets = offsets.data();
+        column.data = data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(data.data());
+        column.decimal128_words = nullptr;
+        column.decimal_precision_is_set = false;
+        column.decimal_precision = 0;
+        column.decimal_scale_is_set = false;
+        column.decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 1;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = &column;
+    }
+};
+
+struct Utf8Int64JoinBatchOwned
+{
+    std::vector<uint8_t> key_null_bitmap;
+    std::vector<int32_t> key_offsets;
+    String key_data;
+
+    std::vector<int64_t> payload_values;
+    std::vector<uint8_t> payload_null_bitmap;
+
+    TiforthExecutionColumnViewV2 columns[2]{};
+    TiforthBatchViewV2 batch{};
+
+    Utf8Int64JoinBatchOwned(const std::vector<Utf8Int64Row> & rows, uint32_t ownership_mode)
+    {
+        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+        key_offsets.reserve(rows.size() + 1);
+        key_offsets.push_back(0);
+
+        payload_values.reserve(rows.size());
+        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].first.has_value())
+            {
+                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                key_data.append(rows[i].first.value());
+            }
+            key_offsets.push_back(static_cast<int32_t>(key_data.size()));
+
+            if (rows[i].second.has_value())
+            {
+                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                payload_values.push_back(rows[i].second.value());
+            }
+            else
+            {
+                payload_values.push_back(0);
+            }
+        }
+
+        columns[0].physical_type = PHYSICAL_TYPE_UTF8;
+        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
+        columns[0].null_bitmap_bit_offset = 0;
+        columns[0].row_offset = 0;
+        columns[0].values = nullptr;
+        columns[0].offsets = key_offsets.data();
+        columns[0].data = key_data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(key_data.data());
+        columns[0].decimal128_words = nullptr;
+        columns[0].decimal_precision_is_set = false;
+        columns[0].decimal_precision = 0;
+        columns[0].decimal_scale_is_set = false;
+        columns[0].decimal_scale = 0;
+
+        columns[1].physical_type = PHYSICAL_TYPE_INT64;
+        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
+        columns[1].null_bitmap_bit_offset = 0;
+        columns[1].row_offset = 0;
+        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
+        columns[1].offsets = nullptr;
+        columns[1].data = nullptr;
+        columns[1].decimal128_words = nullptr;
+        columns[1].decimal_precision_is_set = false;
+        columns[1].decimal_precision = 0;
+        columns[1].decimal_scale_is_set = false;
+        columns[1].decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 2;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = columns;
+    }
+};
+
+struct Int64Int64JoinBatchOwned
+{
+    std::vector<int64_t> key_values;
+    std::vector<uint8_t> key_null_bitmap;
+
+    std::vector<int64_t> payload_values;
+    std::vector<uint8_t> payload_null_bitmap;
+
+    TiforthExecutionColumnViewV2 columns[2]{};
+    TiforthBatchViewV2 batch{};
+
+    Int64Int64JoinBatchOwned(const std::vector<Int64Int64Row> & rows, uint32_t ownership_mode)
+    {
+        key_values.reserve(rows.size());
+        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        payload_values.reserve(rows.size());
+        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
+
+        for (size_t i = 0; i < rows.size(); ++i)
+        {
+            if (rows[i].first.has_value())
+            {
+                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                key_values.push_back(rows[i].first.value());
+            }
+            else
+            {
+                key_values.push_back(0);
+            }
+
+            if (rows[i].second.has_value())
+            {
+                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+                payload_values.push_back(rows[i].second.value());
+            }
+            else
+            {
+                payload_values.push_back(0);
+            }
+        }
+
+        columns[0].physical_type = PHYSICAL_TYPE_INT64;
+        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
+        columns[0].null_bitmap_bit_offset = 0;
+        columns[0].row_offset = 0;
+        columns[0].values = key_values.empty() ? nullptr : key_values.data();
+        columns[0].offsets = nullptr;
+        columns[0].data = nullptr;
+        columns[0].decimal128_words = nullptr;
+        columns[0].decimal_precision_is_set = false;
+        columns[0].decimal_precision = 0;
+        columns[0].decimal_scale_is_set = false;
+        columns[0].decimal_scale = 0;
+
+        columns[1].physical_type = PHYSICAL_TYPE_INT64;
+        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
+        columns[1].null_bitmap_bit_offset = 0;
+        columns[1].row_offset = 0;
+        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
+        columns[1].offsets = nullptr;
+        columns[1].data = nullptr;
+        columns[1].decimal128_words = nullptr;
+        columns[1].decimal_precision_is_set = false;
+        columns[1].decimal_precision = 0;
+        columns[1].decimal_scale_is_set = false;
+        columns[1].decimal_scale = 0;
+
+        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        batch.ownership_mode = ownership_mode;
+        batch.column_count = 2;
+        batch.row_count = static_cast<uint32_t>(rows.size());
+        batch.columns = columns;
+    }
+};
+
+class ExecutionHandles
+{
+public:
+    explicit ExecutionHandles(const TiforthExecutionHostV2Api & api_)
+        : api(api_)
+    {}
+
+    ExecutionHandles(const ExecutionHandles &) = delete;
+    ExecutionHandles & operator=(const ExecutionHandles &) = delete;
+
+    ~ExecutionHandles()
+    {
+        if (instance != nullptr)
+            api.release_instance(instance);
+        if (executable != nullptr)
+            api.release_executable(executable);
+    }
+
+    TiforthExecutionInstanceHandleV2 * buildAndOpen(const TiforthExecutionBuildRequestV2 & request)
+    {
+        auto status = makeStatus();
+        api.build(&request, &status, &executable);
+        ensureStatusOk("build", status);
+        if (executable == nullptr)
+            throw std::runtime_error("build returned null executable");
+
+        status = makeStatus();
+        api.open(executable, &status, &instance);
+        ensureStatusOk("open", status);
+        if (instance == nullptr)
+            throw std::runtime_error("open returned null instance");
+
+        return instance;
+    }
+
+private:
+    const TiforthExecutionHostV2Api & api;
+    TiforthExecutionExecutableHandleV2 * executable = nullptr;
+    TiforthExecutionInstanceHandleV2 * instance = nullptr;
+};
+
+void drainJoinOutput(
+    const TiforthExecutionHostV2Api & api,
+    TiforthExecutionInstanceHandleV2 * instance,
+    TiforthStatusV2 & status,
+    JoinRunResult & result)
+{
+    while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
+    {
+        auto continued_output = makeBatch();
+        status = makeStatus();
+        api.continue_output(instance, &status, &continued_output);
+        ensureStatusKindOk("continue_output", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(continued_output, result.rows);
+    }
+
+    if (status.code != STATUS_CODE_NONE)
+    {
+        throw std::runtime_error(
+            fmt::format("join produced unexpected status code {}", status.code));
+    }
+}
+
+} // namespace
+
+std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
+{
+#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
+    (void)error;
+
+    TiforthExecutionHostV2Api api;
+    api.build = tiforth_execution_host_v2_build;
+    api.open = tiforth_execution_host_v2_open;
+    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
+    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
+    api.drive_end_of_input_with_output = tiforth_execution_host_v2_drive_end_of_input_with_output;
+    api.continue_output = tiforth_execution_host_v2_continue_output;
+    api.finish = tiforth_execution_host_v2_finish;
+    api.release_executable = tiforth_execution_host_v2_release_executable;
+    api.release_instance = tiforth_execution_host_v2_release_instance;
+    return api;
+#else
+    error
+        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
+          "-DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> to run this donor adapter test";
+    return std::nullopt;
+#endif
+}
+
+bool requiresStrictRuntimeExecution()
+{
+    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
+    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
+}
+
+CastRunResult runCastUtf8ToDecimal(
+    const TiforthExecutionHostV2Api & api,
+    const std::vector<std::optional<String>> & input,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t sql_mode,
+    uint8_t decimal_precision,
+    int8_t decimal_scale)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = PLAN_KIND_CAST_UTF8_TO_DECIMAL;
+    build_request.ambient_requirement_mask = AMBIENT_REQUIREMENT_SQL_MODE;
+    build_request.sql_mode = sql_mode;
+    build_request.session_charset = 0;
+    build_request.default_collation = 0;
+    build_request.decimal_precision_is_set = true;
+    build_request.decimal_precision = decimal_precision;
+    build_request.decimal_scale_is_set = true;
+    build_request.decimal_scale = decimal_scale;
+    build_request.max_block_size = 0;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    CastRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    const size_t chunk_size = std::max<size_t>(1, (input.size() + partition_count - 1) / partition_count);
+    std::vector<Utf8BatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+    {
+        const size_t batch_count = input.empty() ? 0 : (input.size() + chunk_size - 1) / chunk_size;
+        retained_batches.reserve(batch_count);
+    }
+
+    for (size_t start = 0; start < input.size(); start += chunk_size)
+    {
+        const size_t end = std::min(input.size(), start + chunk_size);
+        std::vector<std::optional<String>> batch_rows(
+            input.begin() + static_cast<ptrdiff_t>(start),
+            input.begin() + static_cast<ptrdiff_t>(end));
+
+        const TiforthBatchViewV2 * input_batch = nullptr;
+        std::optional<Utf8BatchOwned> borrowed_batch;
+        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        {
+            retained_batches.emplace_back(batch_rows, ownership_mode);
+            input_batch = &retained_batches.back().batch;
+        }
+        else
+        {
+            borrowed_batch.emplace(batch_rows, ownership_mode);
+            input_batch = &borrowed_batch->batch;
+        }
+
+        auto status = makeStatus();
+        auto output = makeBatch();
+        api.drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
+        ensureStatusOk("drive_input_batch", status);
+        result.warning_count += status.warning_count;
+        appendCastOutputRows(output, result.output);
+    }
+
+    auto status = makeStatus();
+    api.drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
+    ensureStatusOk("drive_end_of_input", status);
+
+    auto continued_output = makeBatch();
+    status = makeStatus();
+    api.continue_output(instance, &status, &continued_output);
+    if (status.kind == STATUS_KIND_OK)
+    {
+        if (status.code != STATUS_CODE_NONE)
+            throwStatusError("continue_output", status);
+        if (continued_output.row_count != 0 || continued_output.column_count != 0)
+        {
+            throw std::runtime_error(
+                "continue_output returned unexpected rows for scalar cast execution");
+        }
+    }
+    else if (!(status.kind == STATUS_KIND_PROTOCOL_ERROR && status.code == STATUS_CODE_INSTANCE_FINISH_ONLY))
+    {
+        throwStatusError("continue_output", status);
+    }
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    return result;
+}
+
+JoinRunResult runJoinUtf8KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Utf8Int64Row> & build_rows,
+    const std::vector<Utf8Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation,
+    uint32_t max_block_size,
+    bool build_end_with_output,
+    bool probe_end_with_output)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = plan_kind;
+    build_request.ambient_requirement_mask = ambient_requirement_mask;
+    build_request.sql_mode = 0;
+    build_request.session_charset = session_charset;
+    build_request.default_collation = default_collation;
+    build_request.decimal_precision_is_set = false;
+    build_request.decimal_precision = 0;
+    build_request.decimal_scale_is_set = false;
+    build_request.decimal_scale = 0;
+    build_request.max_block_size = max_block_size;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    JoinRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    std::vector<Utf8Int64JoinBatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        retained_batches.reserve(8);
+
+    auto drive_input_rows = [&](const std::vector<Utf8Int64Row> & rows, uint32_t input_id) {
+        const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
+        for (size_t start = 0; start < rows.size(); start += chunk_size)
+        {
+            const size_t end = std::min(rows.size(), start + chunk_size);
+            std::vector<Utf8Int64Row> chunk(
+                rows.begin() + static_cast<ptrdiff_t>(start),
+                rows.begin() + static_cast<ptrdiff_t>(end));
+
+            const TiforthBatchViewV2 * input_batch = nullptr;
+            std::optional<Utf8Int64JoinBatchOwned> borrowed_batch;
+            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+            {
+                retained_batches.emplace_back(chunk, ownership_mode);
+                input_batch = &retained_batches.back().batch;
+            }
+            else
+            {
+                borrowed_batch.emplace(chunk, ownership_mode);
+                input_batch = &borrowed_batch->batch;
+            }
+
+            auto status = makeStatus();
+            auto output = makeBatch();
+            api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+            ensureStatusKindOk("drive_input_batch", status);
+            result.warning_count += status.warning_count;
+            appendJoinOutputRows(output, result.rows);
+            drainJoinOutput(api, instance, status, result);
+        }
+    };
+
+    drive_input_rows(build_rows, INPUT_ID_BUILD);
+
+    auto status = makeStatus();
+    if (build_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        ensureStatusKindOk("drive_end_of_input(build)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
+
+    drive_input_rows(probe_rows, INPUT_ID_PROBE);
+
+    status = makeStatus();
+    if (probe_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        ensureStatusKindOk("drive_end_of_input(probe)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    result.rows = canonicalizeJoinRows(std::move(result.rows));
+    return result;
+}
+
+JoinRunResult runJoinInt64KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Int64Int64Row> & build_rows,
+    const std::vector<Int64Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation,
+    uint32_t max_block_size,
+    bool build_end_with_output,
+    bool probe_end_with_output)
+{
+    TiforthExecutionBuildRequestV2 build_request{};
+    build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+    build_request.plan_kind = plan_kind;
+    build_request.ambient_requirement_mask = ambient_requirement_mask;
+    build_request.sql_mode = 0;
+    build_request.session_charset = session_charset;
+    build_request.default_collation = default_collation;
+    build_request.decimal_precision_is_set = false;
+    build_request.decimal_precision = 0;
+    build_request.decimal_scale_is_set = false;
+    build_request.decimal_scale = 0;
+    build_request.max_block_size = max_block_size;
+
+    ExecutionHandles handles(api);
+    TiforthExecutionInstanceHandleV2 * instance = handles.buildAndOpen(build_request);
+
+    JoinRunResult result;
+    const size_t partition_count = std::max<size_t>(1, partitions);
+    std::vector<Int64Int64JoinBatchOwned> retained_batches;
+    if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        retained_batches.reserve(8);
+
+    auto drive_input_rows = [&](const std::vector<Int64Int64Row> & rows, uint32_t input_id) {
+        const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);
+        for (size_t start = 0; start < rows.size(); start += chunk_size)
+        {
+            const size_t end = std::min(rows.size(), start + chunk_size);
+            std::vector<Int64Int64Row> chunk(
+                rows.begin() + static_cast<ptrdiff_t>(start),
+                rows.begin() + static_cast<ptrdiff_t>(end));
+
+            const TiforthBatchViewV2 * input_batch = nullptr;
+            std::optional<Int64Int64JoinBatchOwned> borrowed_batch;
+            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+            {
+                retained_batches.emplace_back(chunk, ownership_mode);
+                input_batch = &retained_batches.back().batch;
+            }
+            else
+            {
+                borrowed_batch.emplace(chunk, ownership_mode);
+                input_batch = &borrowed_batch->batch;
+            }
+
+            auto status = makeStatus();
+            auto output = makeBatch();
+            api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+            ensureStatusKindOk("drive_input_batch", status);
+            result.warning_count += status.warning_count;
+            appendJoinOutputRows(output, result.rows);
+            drainJoinOutput(api, instance, status, result);
+        }
+    };
+
+    drive_input_rows(build_rows, INPUT_ID_BUILD);
+
+    auto status = makeStatus();
+    if (build_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(build)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_BUILD, &status);
+        ensureStatusKindOk("drive_end_of_input(build)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
+
+    drive_input_rows(probe_rows, INPUT_ID_PROBE);
+
+    status = makeStatus();
+    if (probe_end_with_output)
+    {
+        auto output = makeBatch();
+        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &output);
+        ensureStatusKindOk("drive_end_of_input_with_output(probe)", status);
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(output, result.rows);
+        drainJoinOutput(api, instance, status, result);
+    }
+    else
+    {
+        api.drive_end_of_input(instance, INPUT_ID_PROBE, &status);
+        ensureStatusKindOk("drive_end_of_input(probe)", status);
+        result.warning_count += status.warning_count;
+        drainJoinOutput(api, instance, status, result);
+    }
+
+    status = makeStatus();
+    api.finish(instance, &status);
+    ensureStatusOk("finish", status);
+
+    result.rows = canonicalizeJoinRows(std::move(result.rows));
+    return result;
+}
+
+std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows)
+{
+    const auto rank_value = [](const std::optional<int64_t> & value) {
+        return std::make_pair(value.has_value() ? 1 : 0, value.value_or(0));
+    };
+
+    std::sort(
+        rows.begin(),
+        rows.end(),
+        [&](const JoinOutputRow & lhs, const JoinOutputRow & rhs) {
+            const auto lhs_build = rank_value(lhs.first);
+            const auto rhs_build = rank_value(rhs.first);
+            if (lhs_build != rhs_build)
+                return lhs_build < rhs_build;
+            return rank_value(lhs.second) < rank_value(rhs.second);
+        });
+    return rows;
+}
+
+} // namespace DB::Tiforth

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -667,7 +667,15 @@ JoinRunResult runJoinKeyInt64Payload(
     const size_t partition_count = std::max<size_t>(1, partitions);
     std::vector<BatchOwned> retained_batches;
     if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        retained_batches.reserve(8);
+    {
+        const auto batch_count_for_rows = [&](size_t row_count) -> size_t {
+            if (row_count == 0)
+                return 0;
+            const size_t chunk_size = std::max<size_t>(1, (row_count + partition_count - 1) / partition_count);
+            return (row_count + chunk_size - 1) / chunk_size;
+        };
+        retained_batches.reserve(batch_count_for_rows(build_rows.size()) + batch_count_for_rows(probe_rows.size()));
+    }
 
     auto drive_input_rows = [&](const std::vector<Row> & rows, uint32_t input_id) {
         const size_t chunk_size = std::max<size_t>(1, (rows.size() + partition_count - 1) / partition_count);

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
@@ -1,0 +1,208 @@
+// Copyright 2026 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <Core/Types.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace DB::Tiforth
+{
+
+constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
+
+constexpr uint32_t PLAN_KIND_CAST_UTF8_TO_DECIMAL = 1;
+constexpr uint32_t PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD = 2;
+constexpr uint32_t PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 6;
+constexpr uint32_t PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 10;
+
+constexpr uint32_t INPUT_ID_SCALAR = 0;
+constexpr uint32_t INPUT_ID_BUILD = 0;
+constexpr uint32_t INPUT_ID_PROBE = 1;
+
+constexpr uint32_t STATUS_KIND_OK = 0;
+constexpr uint32_t STATUS_KIND_PROTOCOL_ERROR = 5;
+constexpr uint32_t STATUS_CODE_NONE = 0;
+constexpr uint32_t STATUS_CODE_INSTANCE_FINISH_ONLY = 13;
+constexpr uint32_t STATUS_CODE_MORE_OUTPUT_AVAILABLE = 29;
+
+constexpr uint32_t PHYSICAL_TYPE_INT64 = 1;
+constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
+constexpr uint32_t PHYSICAL_TYPE_DECIMAL128 = 4;
+
+constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
+constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
+
+constexpr uint32_t AMBIENT_REQUIREMENT_SQL_MODE = 1u << 0;
+constexpr uint32_t AMBIENT_REQUIREMENT_CHARSET = 1u << 2;
+constexpr uint32_t AMBIENT_REQUIREMENT_DEFAULT_COLLATION = 1u << 3;
+
+constexpr uint32_t SQL_MODE_TRUNCATE_AS_WARNING = 2;
+constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
+constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
+
+struct TiforthExecutionBuildRequestV2
+{
+    uint32_t abi_version;
+    uint32_t plan_kind;
+    uint32_t ambient_requirement_mask;
+    uint32_t sql_mode;
+    uint32_t session_charset;
+    uint32_t default_collation;
+    bool decimal_precision_is_set;
+    uint8_t decimal_precision;
+    bool decimal_scale_is_set;
+    int8_t decimal_scale;
+    uint32_t max_block_size;
+};
+
+struct TiforthExecutionColumnViewV2
+{
+    uint32_t physical_type;
+    const uint8_t * null_bitmap;
+    uint32_t null_bitmap_bit_offset;
+    uint32_t row_offset;
+    const int64_t * values;
+    const int32_t * offsets;
+    const uint8_t * data;
+    const void * decimal128_words;
+    bool decimal_precision_is_set;
+    uint8_t decimal_precision;
+    bool decimal_scale_is_set;
+    int8_t decimal_scale;
+};
+
+struct TiforthBatchViewV2
+{
+    uint32_t abi_version;
+    uint32_t ownership_mode;
+    uint32_t column_count;
+    uint32_t row_count;
+    const TiforthExecutionColumnViewV2 * columns;
+};
+
+struct TiforthStatusV2
+{
+    uint32_t abi_version;
+    uint32_t kind;
+    uint32_t code;
+    uint32_t warning_count;
+    char message[256];
+};
+
+struct TiforthExecutionExecutableHandleV2;
+struct TiforthExecutionInstanceHandleV2;
+
+struct TiforthExecutionHostV2Api
+{
+    using BuildFn = void (*) (
+        const TiforthExecutionBuildRequestV2 *,
+        TiforthStatusV2 *,
+        TiforthExecutionExecutableHandleV2 **);
+    using OpenFn = void (*) (
+        const TiforthExecutionExecutableHandleV2 *,
+        TiforthStatusV2 *,
+        TiforthExecutionInstanceHandleV2 **);
+    using DriveInputBatchFn = void (*) (
+        TiforthExecutionInstanceHandleV2 *,
+        uint32_t,
+        const TiforthBatchViewV2 *,
+        TiforthStatusV2 *,
+        TiforthBatchViewV2 *);
+    using DriveEndOfInputFn = void (*) (TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
+    using DriveEndOfInputWithOutputFn = void (*) (
+        TiforthExecutionInstanceHandleV2 *,
+        uint32_t,
+        TiforthStatusV2 *,
+        TiforthBatchViewV2 *);
+    using ContinueOutputFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
+    using FinishFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
+    using ReleaseExecutableFn = void (*) (TiforthExecutionExecutableHandleV2 *);
+    using ReleaseInstanceFn = void (*) (TiforthExecutionInstanceHandleV2 *);
+
+    BuildFn build = nullptr;
+    OpenFn open = nullptr;
+    DriveInputBatchFn drive_input_batch = nullptr;
+    DriveEndOfInputFn drive_end_of_input = nullptr;
+    DriveEndOfInputWithOutputFn drive_end_of_input_with_output = nullptr;
+    ContinueOutputFn continue_output = nullptr;
+    FinishFn finish = nullptr;
+    ReleaseExecutableFn release_executable = nullptr;
+    ReleaseInstanceFn release_instance = nullptr;
+};
+
+std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error);
+bool requiresStrictRuntimeExecution();
+
+using Utf8Int64Row = std::pair<std::optional<String>, std::optional<int64_t>>;
+using Int64Int64Row = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
+using JoinOutputRow = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
+
+struct CastRunResult
+{
+    std::vector<std::optional<String>> output;
+    uint32_t warning_count = 0;
+};
+
+struct JoinRunResult
+{
+    std::vector<JoinOutputRow> rows;
+    uint32_t warning_count = 0;
+};
+
+CastRunResult runCastUtf8ToDecimal(
+    const TiforthExecutionHostV2Api & api,
+    const std::vector<std::optional<String>> & input,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t sql_mode,
+    uint8_t decimal_precision,
+    int8_t decimal_scale);
+
+JoinRunResult runJoinUtf8KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Utf8Int64Row> & build_rows,
+    const std::vector<Utf8Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation,
+    uint32_t max_block_size = 0,
+    bool build_end_with_output = true,
+    bool probe_end_with_output = true);
+
+JoinRunResult runJoinInt64KeyInt64Payload(
+    const TiforthExecutionHostV2Api & api,
+    uint32_t plan_kind,
+    const std::vector<Int64Int64Row> & build_rows,
+    const std::vector<Int64Int64Row> & probe_rows,
+    size_t partitions,
+    uint32_t ownership_mode,
+    uint32_t ambient_requirement_mask,
+    uint32_t session_charset,
+    uint32_t default_collation,
+    uint32_t max_block_size = 0,
+    bool build_end_with_output = true,
+    bool probe_end_with_output = true);
+
+std::vector<JoinOutputRow> canonicalizeJoinRows(std::vector<JoinOutputRow> rows);
+
+} // namespace DB::Tiforth

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -7,14 +7,15 @@ adapter proving tests:
 - `gtest_tiforth_execution_host_v2_inner_hash_join.cpp`
 
 Runtime symbol dispatch (`dlopen` / `dlsym`) is not used on this path.
-These host-v2 proving tests are compiled into `gtests_dbms` only when
+These host-v2 proving tests are compiled into `gtests_dbms` and
+`gtests_tiforth_execution_host_v2` when
 `-DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON` is set.
 
 ## Bootstrap submodules (fresh donor worktree)
 
 Before running the linked host-v2 configure/build commands in a fresh worktree,
 initialize the required donor submodules (including nested dependencies used by
-`gtests_dbms`) with:
+the linked proving binaries) with:
 
 ```bash
 ./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -44,12 +45,13 @@ cmake -S . -B /tmp/tiflash-linked-host-v2 -GNinja \
 ## Build
 
 ```bash
-cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
+cmake --build /tmp/tiflash-linked-host-v2 --target gtests_tiforth_execution_host_v2
 ```
 
 ## Run strict-mode proving tests
 
 ```bash
+TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
   -R TestTiforthExecutionHostV2LinkedStrict \
   --output-on-failure
@@ -58,6 +60,6 @@ ctest --test-dir /tmp/tiflash-linked-host-v2 \
 The strict CTest entry runs this exact proving-slice gtest filter:
 
 ```bash
-/tmp/tiflash-linked-host-v2/dbms/gtests_dbms \
+/tmp/tiflash-linked-host-v2/dbms/gtests_tiforth_execution_host_v2 \
   --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
 ```

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -10,6 +10,16 @@ Runtime symbol dispatch (`dlopen` / `dlsym`) is not used on this path.
 These host-v2 proving tests are compiled into `gtests_dbms` only when
 `-DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON` is set.
 
+## Bootstrap submodules (fresh donor worktree)
+
+Before running the linked host-v2 configure/build commands in a fresh worktree,
+initialize the required donor submodules (including nested dependencies used by
+`gtests_dbms`) with:
+
+```bash
+./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+```
+
 ## Configure
 
 Choose one linked-library input mode and keep the path absolute.
@@ -40,8 +50,14 @@ cmake --build /tmp/tiflash-linked-host-v2 --target gtests_dbms
 ## Run strict-mode proving tests
 
 ```bash
-TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
-  -R TestTiforthExecutionHostV2 \
+  -R TestTiforthExecutionHostV2LinkedStrict \
   --output-on-failure
+```
+
+The strict CTest entry runs this exact proving-slice gtest filter:
+
+```bash
+/tmp/tiflash-linked-host-v2/dbms/gtests_dbms \
+  --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
 ```

--- a/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
+++ b/dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+# Keep bootstrap bounded to the linked host-v2 proving path. A full
+# --recursive walk pulls many unrelated nested deps (for example grpc/bloaty
+# trees), is slow on fresh worktrees, and can fail before reaching configure.
+git submodule update --init \
+  contrib/abseil-cpp \
+  contrib/aws \
+  contrib/aws-c-auth \
+  contrib/aws-c-cal \
+  contrib/aws-c-common \
+  contrib/aws-c-compression \
+  contrib/aws-c-event-stream \
+  contrib/aws-c-http \
+  contrib/aws-c-io \
+  contrib/aws-c-mqtt \
+  contrib/aws-c-s3 \
+  contrib/aws-c-sdkutils \
+  contrib/aws-checksums \
+  contrib/aws-crt-cpp \
+  contrib/aws-s2n-tls \
+  contrib/benchmark \
+  contrib/boost \
+  contrib/boringssl \
+  contrib/cctz \
+  contrib/client-c \
+  contrib/double-conversion \
+  contrib/fmtlib \
+  contrib/googletest \
+  contrib/grpc \
+  contrib/highfive \
+  contrib/jemalloc \
+  contrib/kvproto \
+  contrib/lz4 \
+  contrib/magic_enum \
+  contrib/poco \
+  contrib/prometheus-cpp \
+  contrib/protobuf \
+  contrib/re2 \
+  contrib/simdjson \
+  contrib/simsimd \
+  contrib/tiflash-proxy \
+  contrib/tipb \
+  contrib/usearch \
+  contrib/xxHash \
+  contrib/zlib-ng \
+  contrib/zstd
+
+# Minimal nested submodules required by the linked host-v2 proving configure.
+# Keep this explicit instead of blanket recursion.
+git -C contrib/grpc submodule update --init third_party/cares/cares
+git -C contrib/prometheus-cpp submodule update --init 3rdparty/civetweb
+git -C contrib/client-c submodule update --init \
+  third_party/abseil-cpp \
+  third_party/googletest \
+  third_party/kvproto \
+  third_party/libfiu

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -653,6 +653,8 @@ TEST_F(
     const std::vector<std::optional<String>> input = {
         String("bad"),
         String("1.2.3"),
+        String("-1.2.3"),
+        String("+1.2.3"),
         String("12.340"),
         String("-0.500"),
         std::nullopt,
@@ -683,6 +685,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningPari
     const std::vector<std::optional<String>> input = {
         String("bad"),
         String("1.2.3"),
+        String("-1.2.3"),
+        String("+1.2.3"),
         String("12.340"),
         String("-0.500"),
         std::nullopt,

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -531,7 +531,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
     auto donor_native = runDonorNativeCastAsString(input);
     ASSERT_COLUMN_EQ(
         createColumn<Nullable<String>>({
-            String("0.000"),
+            String("1.200"),
             String("0.000"),
             String("12.340"),
             String("-0.500"),
@@ -577,8 +577,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
     auto donor_native = runDonorNativeCastAsString(input);
     ASSERT_COLUMN_EQ(
         createColumn<Nullable<String>>({
-            String("0.000"),
-            String("0.000"),
+            String("-1.200"),
+            String("1.200"),
             String("0.000"),
             String("0.000"),
             String("-0.500"),

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <fmt/core.h>
 #include <iostream>
 #include <optional>
@@ -161,10 +160,12 @@ struct TiforthExecutionHostV2Api
     ReleaseInstanceFn release_instance = nullptr;
 };
 
-std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
+#if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
+#error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
+#endif
+
+TiforthExecutionHostV2Api linkedExecutionHostV2Api()
 {
-#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
-    (void)error;
     TiforthExecutionHostV2Api api;
     api.build = tiforth_execution_host_v2_build;
     api.open = tiforth_execution_host_v2_open;
@@ -175,22 +176,6 @@ std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
     api.release_executable = tiforth_execution_host_v2_release_executable;
     api.release_instance = tiforth_execution_host_v2_release_instance;
     return api;
-#else
-    error
-        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
-          "and either -DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> "
-          "or -DTIFORTH_FFI_C_LIB_DIR=/abs/path/to/libdir "
-          "(-DTIFORTH_FFI_C_LIB_NAME defaults to tiforth_ffi_c); "
-          "see dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md "
-          "to run this donor adapter test";
-    return std::nullopt;
-#endif
-}
-
-bool requiresStrictRuntimeExecution()
-{
-    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
-    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
 }
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
@@ -452,18 +437,7 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -498,18 +472,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -545,18 +508,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -603,18 +555,7 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -160,7 +160,7 @@ void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2
 }
 
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
-#error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
+#error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
 #endif
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -549,52 +549,6 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
               << std::endl;
 }
 
-TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
-{
-    auto & dag_context = getDAGContext();
-    ScopedDAGFlags scoped_dag_flags(dag_context);
-    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
-
-    const std::vector<std::optional<String>> input = {
-        String("-1.2.3"),
-        String("+1.2.3"),
-        String("-bad"),
-        String("+"),
-        String("-0.500"),
-        std::nullopt,
-    };
-
-    auto donor_native = runDonorNativeCastAsString(input);
-    ASSERT_COLUMN_EQ(
-        createColumn<Nullable<String>>({
-            String("0.000"),
-            String("0.000"),
-            String("0.000"),
-            String("0.000"),
-            String("-0.500"),
-            std::nullopt,
-        }),
-        donor_native);
-    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
-    ASSERT_EQ(donor_warning_count, 0u);
-
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
-
-    ASSERT_EQ(serial.warning_count, donor_warning_count);
-    ASSERT_EQ(parallel.warning_count, donor_warning_count);
-
-    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
-    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
-
-    std::cout << "[tiforth-host-v2-cast-signed-multi-dot] serial=1 warnings=" << serial.warning_count
-              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
-              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
-              << std::endl;
-}
-
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
     auto & dag_context = getDAGContext();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -639,6 +639,41 @@ TEST_F(
     ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2Cast,
+    CastUtf8ToDecimalInvalidSyntaxWarningParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("bad"),
+        String("1.2.3"),
+        String("12.340"),
+        String("-0.500"),
+        std::nullopt,
+        String(""),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+}
+
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
     auto & dag_context = getDAGContext();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -543,6 +543,64 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
               << std::endl;
 }
 
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroParitySerialAndParallel)
+{
+    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("1.2.3"),
+        String("bad"),
+        String("12.340"),
+        String("-0.500"),
+        std::nullopt,
+        String(""),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    ASSERT_COLUMN_EQ(
+        createColumn<Nullable<String>>({
+            String("0.000"),
+            String("0.000"),
+            String("12.340"),
+            String("-0.500"),
+            std::nullopt,
+            String("0.000"),
+        }),
+        donor_native);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast-multi-dot] serial=1 warnings=" << serial.warning_count
+              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
+              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
+              << std::endl;
+}
+
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
     const bool strict_runtime_execution = requiresStrictRuntimeExecution();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -128,55 +128,9 @@ void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHand
 void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
 }
 
-struct TiforthExecutionHostV2Api
-{
-    using BuildFn = void (*)(
-        const TiforthExecutionBuildRequestV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionExecutableHandleV2 **);
-    using OpenFn = void (*)(
-        const TiforthExecutionExecutableHandleV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionInstanceHandleV2 **);
-    using DriveInputBatchFn = void (*)(
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        const TiforthBatchViewV2 *,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using DriveEndOfInputFn = void (*)(TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
-    using ContinueOutputFn = void (*)(TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
-    using FinishFn = void (*)(TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
-    using ReleaseExecutableFn = void (*)(TiforthExecutionExecutableHandleV2 *);
-    using ReleaseInstanceFn = void (*)(TiforthExecutionInstanceHandleV2 *);
-
-    BuildFn build = nullptr;
-    OpenFn open = nullptr;
-    DriveInputBatchFn drive_input_batch = nullptr;
-    DriveEndOfInputFn drive_end_of_input = nullptr;
-    ContinueOutputFn continue_output = nullptr;
-    FinishFn finish = nullptr;
-    ReleaseExecutableFn release_executable = nullptr;
-    ReleaseInstanceFn release_instance = nullptr;
-};
-
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
 #error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
 #endif
-
-TiforthExecutionHostV2Api linkedExecutionHostV2Api()
-{
-    TiforthExecutionHostV2Api api;
-    api.build = tiforth_execution_host_v2_build;
-    api.open = tiforth_execution_host_v2_open;
-    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
-    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
-    api.continue_output = tiforth_execution_host_v2_continue_output;
-    api.finish = tiforth_execution_host_v2_finish;
-    api.release_executable = tiforth_execution_host_v2_release_executable;
-    api.release_instance = tiforth_execution_host_v2_release_instance;
-    return api;
-}
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
 {
@@ -319,7 +273,6 @@ public:
     }
 
     void runAdapterCast(
-        TiforthExecutionHostV2Api & api,
         const std::vector<std::optional<String>> & input,
         size_t partitions,
         uint32_t ownership_mode,
@@ -342,13 +295,13 @@ public:
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
 
         TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
+        tiforth_execution_host_v2_build(&build_request, &status, &executable);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(executable, nullptr);
 
         TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
+        tiforth_execution_host_v2_open(executable, &status, &instance);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(instance, nullptr);
@@ -383,7 +336,7 @@ public:
 
             TiforthBatchViewV2 output{};
             output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-            api.drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
+            tiforth_execution_host_v2_drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
 
             ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
             ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
@@ -407,13 +360,13 @@ public:
             }
         }
 
-        api.drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
+        tiforth_execution_host_v2_drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
 
         TiforthBatchViewV2 continued_output{};
         continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.continue_output(instance, &status, &continued_output);
+        tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
         ASSERT_EQ(continued_output.row_count, 0u);
         ASSERT_EQ(continued_output.column_count, 0u);
         if (status.kind != STATUS_KIND_OK)
@@ -426,18 +379,17 @@ public:
             ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         }
 
-        api.finish(instance, &status);
+        tiforth_execution_host_v2_finish(instance, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
 
-        api.release_instance(instance);
-        api.release_executable(executable);
+        tiforth_execution_host_v2_release_instance(instance);
+        tiforth_execution_host_v2_release_executable(executable);
     }
 };
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -455,9 +407,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     const auto donor_warning_count = dag_context.getWarningCount();
 
     AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
     AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -472,7 +424,6 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -490,9 +441,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
     ASSERT_GT(donor_warning_count, 0u);
 
     AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
     AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -508,7 +459,6 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -537,9 +487,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
     ASSERT_EQ(donor_warning_count, 0u);
 
     AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
     AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -555,7 +505,6 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -574,9 +523,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningPari
     ASSERT_EQ(donor_warning_count, 0u);
 
     AdapterRunResult serial;
-    runAdapterCast(api, input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
     AdapterRunResult parallel;
-    runAdapterCast(api, input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstddef>
 #include <cstdint>
 #include <fmt/core.h>
@@ -44,6 +45,36 @@ constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
 constexpr uint32_t AMBIENT_REQUIREMENT_SQL_MODE = 1u << 0;
 
 constexpr const char * FUNC_NAME_TIDB_CAST = "tidb_cast";
+constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
+
+class ScopedRuntimeDylibEnvOverride
+{
+public:
+    explicit ScopedRuntimeDylibEnvOverride(const char * value)
+    {
+        if (const char * current = std::getenv("TIFORTH_FFI_C_DYLIB"); current != nullptr)
+        {
+            had_previous_value = true;
+            previous_value = current;
+        }
+        applied = (::setenv("TIFORTH_FFI_C_DYLIB", value, 1) == 0);
+    }
+
+    ~ScopedRuntimeDylibEnvOverride()
+    {
+        if (had_previous_value)
+            (void)::setenv("TIFORTH_FFI_C_DYLIB", previous_value.c_str(), 1);
+        else
+            (void)::unsetenv("TIFORTH_FFI_C_DYLIB");
+    }
+
+    bool ok() const { return applied; }
+
+private:
+    bool had_previous_value = false;
+    bool applied = false;
+    String previous_value;
+};
 
 struct TiforthExecutionBuildRequestV2
 {
@@ -413,6 +444,38 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     std::cout << "[tiforth-host-v2-cast] serial=1 warnings=" << serial.warning_count << " rows=" << serial.output.size()
               << " parallel=2 warnings=" << parallel.warning_count << " rows=" << parallel.output.size()
               << " donor_warnings=" << donor_warning_count << " parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("12.345"),
+        String("-7.800"),
+        std::nullopt,
+        String("0"),
+        String("999.999"),
+        String("1.2"),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = dag_context.getWarningCount();
+
+    AdapterRunResult serial;
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
 }
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -369,15 +369,8 @@ public:
         tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
         ASSERT_EQ(continued_output.row_count, 0u);
         ASSERT_EQ(continued_output.column_count, 0u);
-        if (status.kind != STATUS_KIND_OK)
-        {
-            ASSERT_EQ(status.kind, STATUS_KIND_PROTOCOL_ERROR) << status.message;
-            ASSERT_EQ(status.code, STATUS_CODE_INSTANCE_FINISH_ONLY) << status.message;
-        }
-        else
-        {
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        }
+        ASSERT_EQ(status.kind, STATUS_KIND_PROTOCOL_ERROR) << status.message;
+        ASSERT_EQ(status.code, STATUS_CODE_INSTANCE_FINISH_ONLY) << status.message;
 
         tiforth_execution_host_v2_finish(instance, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -605,6 +605,40 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
               << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2Cast,
+    CastUtf8ToDecimalScaleLossWarningParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("1.2395"),
+        String("-7.8001"),
+        std::nullopt,
+        String("999.9999"),
+        String("0.0004"),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_GT(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+}
+
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
     auto & dag_context = getDAGContext();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -503,6 +503,98 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
               << std::endl;
 }
 
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
+{
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("-1.2.3"),
+        String("+1.2.3"),
+        String("-bad"),
+        String("+"),
+        String("-0.500"),
+        std::nullopt,
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    ASSERT_COLUMN_EQ(
+        createColumn<Nullable<String>>({
+            String("0.000"),
+            String("0.000"),
+            String("0.000"),
+            String("0.000"),
+            String("-0.500"),
+            std::nullopt,
+        }),
+        donor_native);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast-signed-multi-dot] serial=1 warnings=" << serial.warning_count
+              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
+              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
+              << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
+{
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("-1.2.3"),
+        String("+1.2.3"),
+        String("-bad"),
+        String("+"),
+        String("-0.500"),
+        std::nullopt,
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    ASSERT_COLUMN_EQ(
+        createColumn<Nullable<String>>({
+            String("0.000"),
+            String("0.000"),
+            String("0.000"),
+            String("0.000"),
+            String("-0.500"),
+            std::nullopt,
+        }),
+        donor_native);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    AdapterRunResult serial;
+    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
+    AdapterRunResult parallel;
+    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+
+    std::cout << "[tiforth-host-v2-cast-signed-multi-dot] serial=1 warnings=" << serial.warning_count
+              << " rows=" << serial.output.size() << " parallel=2 warnings=" << parallel.warning_count
+              << " rows=" << parallel.output.size() << " donor_warnings=" << donor_warning_count << " parity=ok"
+              << std::endl;
+}
+
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
     auto & dag_context = getDAGContext();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -12,37 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <Functions/TiforthExecutionHostV2Adapter.h>
 #include <TestUtils/FunctionTestUtils.h>
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <cstdlib>
-#include <cstddef>
-#include <cstdint>
-#include <fmt/core.h>
 #include <iostream>
-#include <optional>
-#include <string>
-#include <vector>
 
 namespace DB::tests
 {
 namespace
 {
-
-constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
-constexpr uint32_t PLAN_KIND_CAST_UTF8_TO_DECIMAL = 1;
-constexpr uint32_t INPUT_ID_SCALAR = 0;
-constexpr uint32_t SQL_MODE_TRUNCATE_AS_WARNING = 2;
-constexpr uint32_t STATUS_KIND_OK = 0;
-constexpr uint32_t STATUS_KIND_PROTOCOL_ERROR = 5;
-constexpr uint32_t STATUS_CODE_NONE = 0;
-constexpr uint32_t STATUS_CODE_INSTANCE_FINISH_ONLY = 13;
-constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
-constexpr uint32_t PHYSICAL_TYPE_DECIMAL128 = 4;
-constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
-constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_SQL_MODE = 1u << 0;
 
 constexpr const char * FUNC_NAME_TIDB_CAST = "tidb_cast";
 constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
@@ -76,203 +56,6 @@ private:
     String previous_value;
 };
 
-struct TiforthExecutionBuildRequestV2
-{
-    uint32_t abi_version;
-    uint32_t plan_kind;
-    uint32_t ambient_requirement_mask;
-    uint32_t sql_mode;
-    uint32_t session_charset;
-    uint32_t default_collation;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-    uint32_t max_block_size;
-};
-
-struct TiforthExecutionColumnViewV2
-{
-    uint32_t physical_type;
-    const uint8_t * null_bitmap;
-    uint32_t null_bitmap_bit_offset;
-    uint32_t row_offset;
-    const int64_t * values;
-    const int32_t * offsets;
-    const uint8_t * data;
-    const void * decimal128_words;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-};
-
-struct TiforthBatchViewV2
-{
-    uint32_t abi_version;
-    uint32_t ownership_mode;
-    uint32_t column_count;
-    uint32_t row_count;
-    const TiforthExecutionColumnViewV2 * columns;
-};
-
-struct TiforthStatusV2
-{
-    uint32_t abi_version;
-    uint32_t kind;
-    uint32_t code;
-    uint32_t warning_count;
-    char message[256];
-};
-
-struct TiforthExecutionExecutableHandleV2;
-struct TiforthExecutionInstanceHandleV2;
-
-extern "C"
-{
-void tiforth_execution_host_v2_build(
-    const TiforthExecutionBuildRequestV2 * request,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionExecutableHandleV2 ** out_executable);
-void tiforth_execution_host_v2_open(
-    const TiforthExecutionExecutableHandleV2 * executable,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionInstanceHandleV2 ** out_instance);
-void tiforth_execution_host_v2_drive_input_batch(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    const TiforthBatchViewV2 * input,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_drive_end_of_input(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_continue_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_finish(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
-void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
-}
-
-#if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
-#error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
-#endif
-
-bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
-{
-    if (column.null_bitmap == nullptr || row_count == 0)
-        return true;
-    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
-    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
-}
-
-String uint128ToString(unsigned __int128 value)
-{
-    if (value == 0)
-        return "0";
-
-    String digits;
-    while (value > 0)
-    {
-        const uint8_t digit = static_cast<uint8_t>(value % 10);
-        digits.push_back(static_cast<char>('0' + digit));
-        value /= 10;
-    }
-    std::reverse(digits.begin(), digits.end());
-    return digits;
-}
-
-String formatDecimal128(__int128 value, int8_t scale)
-{
-    const bool negative = value < 0;
-    unsigned __int128 abs_value;
-    if (negative)
-    {
-        // avoid overflow when value is the smallest signed 128-bit number
-        abs_value = static_cast<unsigned __int128>(-(value + 1));
-        abs_value += 1;
-    }
-    else
-    {
-        abs_value = static_cast<unsigned __int128>(value);
-    }
-
-    if (scale == 0)
-    {
-        String rendered = uint128ToString(abs_value);
-        if (negative)
-            rendered.insert(rendered.begin(), '-');
-        return rendered;
-    }
-
-    String digits = uint128ToString(abs_value);
-    const size_t scale_digits = static_cast<size_t>(scale);
-    if (digits.size() <= scale_digits)
-        digits.insert(0, scale_digits + 1 - digits.size(), '0');
-
-    const size_t split = digits.size() - scale_digits;
-    String rendered = fmt::format("{}.{}", digits.substr(0, split), digits.substr(split));
-    if (negative)
-        rendered.insert(rendered.begin(), '-');
-    return rendered;
-}
-
-struct Utf8BatchOwned
-{
-    std::vector<uint8_t> null_bitmap;
-    std::vector<int32_t> offsets;
-    String data;
-    TiforthExecutionColumnViewV2 column{};
-    TiforthBatchViewV2 batch{};
-
-    Utf8BatchOwned(const std::vector<std::optional<String>> & rows, uint32_t ownership_mode)
-    {
-        null_bitmap.assign(rows.size() == 0 ? 0 : (rows.size() + 7) / 8, 0);
-        offsets.reserve(rows.size() + 1);
-        offsets.push_back(0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].has_value())
-            {
-                null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                data.append(rows[i].value());
-            }
-            offsets.push_back(static_cast<int32_t>(data.size()));
-        }
-
-        column.physical_type = PHYSICAL_TYPE_UTF8;
-        column.null_bitmap = null_bitmap.empty() ? nullptr : null_bitmap.data();
-        column.null_bitmap_bit_offset = 0;
-        column.row_offset = 0;
-        column.values = nullptr;
-        column.offsets = offsets.data();
-        column.data = reinterpret_cast<const uint8_t *>(data.data());
-        column.decimal128_words = nullptr;
-        column.decimal_precision_is_set = false;
-        column.decimal_precision = 0;
-        column.decimal_scale_is_set = false;
-        column.decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 1;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = &column;
-    }
-};
-
-struct AdapterRunResult
-{
-    std::vector<std::optional<String>> output;
-    uint32_t warning_count = 0;
-};
-
 class ScopedDAGFlags
 {
 public:
@@ -303,117 +86,37 @@ public:
             {decimal_column, createConstColumn<String>(1, "Nullable(String)")});
     }
 
-    void runAdapterCast(
+    Tiforth::CastRunResult runAdapterCast(
+        const Tiforth::TiforthExecutionHostV2Api & api,
         const std::vector<std::optional<String>> & input,
         size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
+        uint32_t ownership_mode)
     {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_CAST_UTF8_TO_DECIMAL;
-        build_request.ambient_requirement_mask = AMBIENT_REQUIREMENT_SQL_MODE;
-        build_request.sql_mode = SQL_MODE_TRUNCATE_AS_WARNING;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = true;
-        build_request.decimal_precision = 10;
-        build_request.decimal_scale_is_set = true;
-        build_request.decimal_scale = 3;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        tiforth_execution_host_v2_build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        tiforth_execution_host_v2_open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.output.clear();
-        result.warning_count = 0;
-        const size_t chunk_size = std::max<size_t>(1, (input.size() + partitions - 1) / partitions);
-        std::vector<Utf8BatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        {
-            // Retainable ownership requires input buffers to stay alive until finish().
-            const size_t batch_count = input.empty() ? 0 : (input.size() + chunk_size - 1) / chunk_size;
-            retained_batches.reserve(batch_count);
-        }
-
-        for (size_t start = 0; start < input.size(); start += chunk_size)
-        {
-            const size_t end = std::min(input.size(), start + chunk_size);
-            std::vector<std::optional<String>> batch_rows(input.begin() + static_cast<ptrdiff_t>(start), input.begin() + static_cast<ptrdiff_t>(end));
-            std::optional<Utf8BatchOwned> batch;
-            const TiforthBatchViewV2 * input_batch = nullptr;
-            if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            {
-                retained_batches.emplace_back(batch_rows, ownership_mode);
-                input_batch = &retained_batches.back().batch;
-            }
-            else
-            {
-                batch.emplace(batch_rows, ownership_mode);
-                input_batch = &batch->batch;
-            }
-
-            TiforthBatchViewV2 output{};
-            output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-            tiforth_execution_host_v2_drive_input_batch(instance, INPUT_ID_SCALAR, input_batch, &status, &output);
-
-            ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-            result.warning_count += status.warning_count;
-
-            ASSERT_EQ(output.column_count, 1u);
-            const auto & output_column = output.columns[0];
-            ASSERT_EQ(output_column.physical_type, PHYSICAL_TYPE_DECIMAL128);
-
-            const auto * decimal_values = reinterpret_cast<const __int128 *>(output_column.decimal128_words);
-            ASSERT_NE(decimal_values, nullptr);
-            decimal_values += output_column.row_offset;
-            for (size_t row = 0; row < output.row_count; ++row)
-            {
-                if (!isValidRow(output_column, output.row_count, row))
-                {
-                    result.output.push_back(std::nullopt);
-                    continue;
-                }
-                result.output.push_back(formatDecimal128(decimal_values[row], output_column.decimal_scale));
-            }
-        }
-
-        tiforth_execution_host_v2_drive_end_of_input(instance, INPUT_ID_SCALAR, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        TiforthBatchViewV2 continued_output{};
-        continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
-        ASSERT_EQ(continued_output.row_count, 0u);
-        ASSERT_EQ(continued_output.column_count, 0u);
-        ASSERT_EQ(status.kind, STATUS_KIND_PROTOCOL_ERROR) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_INSTANCE_FINISH_ONLY) << status.message;
-
-        tiforth_execution_host_v2_finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        tiforth_execution_host_v2_release_instance(instance);
-        tiforth_execution_host_v2_release_executable(executable);
+        return Tiforth::runCastUtf8ToDecimal(
+            api,
+            input,
+            partitions,
+            ownership_mode,
+            Tiforth::SQL_MODE_TRUNCATE_AS_WARNING,
+            10,
+            3);
     }
 };
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -428,12 +131,10 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
     };
 
     auto donor_native = runDonorNativeCastAsString(input);
-    const auto donor_warning_count = dag_context.getWarningCount();
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -451,6 +152,18 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDyli
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
     ASSERT_TRUE(runtime_dylib_override.ok());
 
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -465,12 +178,10 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDyli
     };
 
     auto donor_native = runDonorNativeCastAsString(input);
-    const auto donor_warning_count = dag_context.getWarningCount();
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -480,6 +191,18 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDyli
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -496,10 +219,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_GT(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -515,6 +236,18 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -542,10 +275,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_EQ(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -561,6 +292,18 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -588,10 +331,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_EQ(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -612,6 +353,18 @@ TEST_F(
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
     ASSERT_TRUE(runtime_dylib_override.ok());
 
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -628,10 +381,8 @@ TEST_F(
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_GT(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -646,6 +397,18 @@ TEST_F(
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
     ASSERT_TRUE(runtime_dylib_override.ok());
 
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -665,10 +428,8 @@ TEST_F(
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_EQ(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);
@@ -678,6 +439,18 @@ TEST_F(
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
     dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
@@ -697,10 +470,8 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningPari
     const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
     ASSERT_EQ(donor_warning_count, 0u);
 
-    AdapterRunResult serial;
-    runAdapterCast(input, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, serial);
-    AdapterRunResult parallel;
-    runAdapterCast(input, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, parallel);
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
 
     ASSERT_EQ(serial.warning_count, donor_warning_count);
     ASSERT_EQ(parallel.warning_count, donor_warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -195,6 +195,20 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_inner_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 12})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_inner_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 102})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "fanout_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
@@ -251,6 +265,20 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_build_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 12})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_build_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
@@ -276,6 +304,20 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
              toNullableVec<Int64>("probe_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_probe_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_probe_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 102})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -446,6 +488,14 @@ public:
             "empty_inner_build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinAllNull(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "all_null_inner_probe_input",
+            "all_null_inner_build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -522,6 +572,14 @@ public:
             "build_outer_empty_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinAllNull(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "all_null_build_outer_probe_input",
+            "all_null_build_outer_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -596,6 +654,14 @@ public:
             concurrency,
             "probe_outer_empty_probe_input",
             "probe_outer_empty_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinAllNull(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "all_null_probe_outer_probe_input",
+            "all_null_probe_outer_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -693,6 +759,24 @@ public:
         return {};
     }
 
+    static std::vector<JoinInputRow> allNullInnerJoinBuildRows()
+    {
+        return {
+            {std::nullopt, 10},
+            {std::nullopt, 11},
+            {std::nullopt, 12},
+        };
+    }
+
+    static std::vector<JoinInputRow> allNullInnerJoinProbeRows()
+    {
+        return {
+            {std::nullopt, 100},
+            {std::nullopt, 101},
+            {std::nullopt, 102},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
     {
         return {
@@ -786,6 +870,23 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> allNullBuildOuterBuildRows()
+    {
+        return {
+            {std::nullopt, 10},
+            {std::nullopt, 11},
+            {std::nullopt, 12},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> allNullBuildOuterProbeRows()
+    {
+        return {
+            {std::nullopt, 100},
+            {std::nullopt, 101},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultProbeOuterBuildRows()
     {
         return {
@@ -875,6 +976,23 @@ public:
             {8, 800},
             {9, 900},
             {std::nullopt, 1000},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> allNullProbeOuterBuildRows()
+    {
+        return {
+            {std::nullopt, 10},
+            {std::nullopt, 11},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> allNullProbeOuterProbeRows()
+    {
+        return {
+            {std::nullopt, 100},
+            {std::nullopt, 101},
+            {std::nullopt, 102},
         };
     }
 
@@ -1505,6 +1623,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadAllNullKeyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinAllNull(1);
+    auto donor_parallel = runDonorNativeInnerJoinAllNull(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullInnerJoinBuildRows(),
+        allNullInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullInnerJoinBuildRows(),
+        allNullInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1886,6 +2042,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadAllNullKeyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinAllNull(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinAllNull(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOuterBuildRows(),
+        allNullBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOuterBuildRows(),
+        allNullBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2251,6 +2445,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadAllNullKeyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinAllNull(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinAllNull(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullProbeOuterBuildRows(),
+        allNullProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullProbeOuterBuildRows(),
+        allNullProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullProbeOuterProbeRows().size());
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -438,6 +438,14 @@ public:
             "build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinEmptyBoth(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "empty_inner_probe_input",
+            "empty_inner_build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -503,6 +511,14 @@ public:
         return runDonorNativeBuildOuterJoinWithInputs(
             concurrency,
             "build_outer_probe_input",
+            "build_outer_empty_build_input");
+    }
+
+    DonorRunResult runDonorNativeBuildOuterJoinEmptyBoth(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_empty_probe_input",
             "build_outer_empty_build_input");
     }
 
@@ -572,6 +588,14 @@ public:
             concurrency,
             "probe_outer_empty_probe_input",
             "probe_outer_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinEmptyBoth(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_empty_probe_input",
+            "probe_outer_empty_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -1443,6 +1467,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadEmptyBothParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinEmptyBoth(1);
+    auto donor_parallel = runDonorNativeInnerJoinEmptyBoth(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyInnerJoinBuildRows(),
+        emptyInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyInnerJoinBuildRows(),
+        emptyInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1786,6 +1848,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadEmptyBothParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinEmptyBoth(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinEmptyBoth(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyBuildOuterBuildRows(),
+        emptyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyBuildOuterBuildRows(),
+        emptyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2102,6 +2202,44 @@ TEST_F(
         8,
         BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
         defaultProbeOuterBuildRows(),
+        emptyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadEmptyBothParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinEmptyBoth(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinEmptyBoth(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyProbeOuterBuildRows(),
+        emptyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyProbeOuterBuildRows(),
         emptyProbeOuterProbeRows(),
         1,
         false,

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -139,62 +139,9 @@ void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHand
 void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
 }
 
-struct TiforthExecutionHostV2Api
-{
-    using BuildFn = void (*) (
-        const TiforthExecutionBuildRequestV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionExecutableHandleV2 **);
-    using OpenFn = void (*) (
-        const TiforthExecutionExecutableHandleV2 *,
-        TiforthStatusV2 *,
-        TiforthExecutionInstanceHandleV2 **);
-    using DriveInputBatchFn = void (*) (
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        const TiforthBatchViewV2 *,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using DriveEndOfInputFn = void (*) (TiforthExecutionInstanceHandleV2 *, uint32_t, TiforthStatusV2 *);
-    using DriveEndOfInputWithOutputFn = void (*) (
-        TiforthExecutionInstanceHandleV2 *,
-        uint32_t,
-        TiforthStatusV2 *,
-        TiforthBatchViewV2 *);
-    using ContinueOutputFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *, TiforthBatchViewV2 *);
-    using FinishFn = void (*) (TiforthExecutionInstanceHandleV2 *, TiforthStatusV2 *);
-    using ReleaseExecutableFn = void (*) (TiforthExecutionExecutableHandleV2 *);
-    using ReleaseInstanceFn = void (*) (TiforthExecutionInstanceHandleV2 *);
-
-    BuildFn build = nullptr;
-    OpenFn open = nullptr;
-    DriveInputBatchFn drive_input_batch = nullptr;
-    DriveEndOfInputFn drive_end_of_input = nullptr;
-    DriveEndOfInputWithOutputFn drive_end_of_input_with_output = nullptr;
-    ContinueOutputFn continue_output = nullptr;
-    FinishFn finish = nullptr;
-    ReleaseExecutableFn release_executable = nullptr;
-    ReleaseInstanceFn release_instance = nullptr;
-};
-
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
 #error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
 #endif
-
-TiforthExecutionHostV2Api linkedExecutionHostV2Api()
-{
-    TiforthExecutionHostV2Api api;
-    api.build = tiforth_execution_host_v2_build;
-    api.open = tiforth_execution_host_v2_open;
-    api.drive_input_batch = tiforth_execution_host_v2_drive_input_batch;
-    api.drive_end_of_input = tiforth_execution_host_v2_drive_end_of_input;
-    api.drive_end_of_input_with_output = tiforth_execution_host_v2_drive_end_of_input_with_output;
-    api.continue_output = tiforth_execution_host_v2_continue_output;
-    api.finish = tiforth_execution_host_v2_finish;
-    api.release_executable = tiforth_execution_host_v2_release_executable;
-    api.release_instance = tiforth_execution_host_v2_release_instance;
-    return api;
-}
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
 {
@@ -573,11 +520,7 @@ public:
         return result;
     }
 
-    void runAdapterInnerJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
+    void runAdapterInnerJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
         TiforthExecutionBuildRequestV2 build_request{};
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -597,13 +540,13 @@ public:
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
 
         TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
+        tiforth_execution_host_v2_build(&build_request, &status, &executable);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(executable, nullptr);
 
         TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
+        tiforth_execution_host_v2_open(executable, &status, &instance);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(instance, nullptr);
@@ -619,7 +562,7 @@ public:
             {
                 TiforthBatchViewV2 continued_output{};
                 continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
+                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -652,7 +595,7 @@ public:
 
                 TiforthBatchViewV2 output{};
                 output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -678,7 +621,7 @@ public:
 
         TiforthBatchViewV2 build_end_output{};
         build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(build_end_output, result.rows);
@@ -688,27 +631,23 @@ public:
 
         TiforthBatchViewV2 probe_end_output{};
         probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
-        api.finish(instance, &status);
+        tiforth_execution_host_v2_finish(instance, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
 
-        api.release_instance(instance);
-        api.release_executable(executable);
+        tiforth_execution_host_v2_release_instance(instance);
+        tiforth_execution_host_v2_release_executable(executable);
 
         result.rows = canonicalizeRows(std::move(result.rows));
     }
 
-    void runAdapterBuildOuterJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
+    void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
         TiforthExecutionBuildRequestV2 build_request{};
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -727,13 +666,13 @@ public:
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
 
         TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
+        tiforth_execution_host_v2_build(&build_request, &status, &executable);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(executable, nullptr);
 
         TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
+        tiforth_execution_host_v2_open(executable, &status, &instance);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(instance, nullptr);
@@ -749,7 +688,7 @@ public:
             {
                 TiforthBatchViewV2 continued_output{};
                 continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
+                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -782,7 +721,7 @@ public:
 
                 TiforthBatchViewV2 output{};
                 output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -806,7 +745,7 @@ public:
 
         TiforthBatchViewV2 build_end_output{};
         build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(build_end_output, result.rows);
@@ -816,27 +755,23 @@ public:
 
         TiforthBatchViewV2 probe_end_output{};
         probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
-        api.finish(instance, &status);
+        tiforth_execution_host_v2_finish(instance, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
 
-        api.release_instance(instance);
-        api.release_executable(executable);
+        tiforth_execution_host_v2_release_instance(instance);
+        tiforth_execution_host_v2_release_executable(executable);
 
         result.rows = canonicalizeRows(std::move(result.rows));
     }
 
-    void runAdapterProbeOuterJoin(
-        TiforthExecutionHostV2Api & api,
-        size_t partitions,
-        uint32_t ownership_mode,
-        AdapterRunResult & result)
+    void runAdapterProbeOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
         TiforthExecutionBuildRequestV2 build_request{};
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -855,13 +790,13 @@ public:
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
 
         TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        api.build(&build_request, &status, &executable);
+        tiforth_execution_host_v2_build(&build_request, &status, &executable);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(executable, nullptr);
 
         TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        api.open(executable, &status, &instance);
+        tiforth_execution_host_v2_open(executable, &status, &instance);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
         ASSERT_NE(instance, nullptr);
@@ -877,7 +812,7 @@ public:
             {
                 TiforthBatchViewV2 continued_output{};
                 continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.continue_output(instance, &status, &continued_output);
+                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -910,7 +845,7 @@ public:
 
                 TiforthBatchViewV2 output{};
                 output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                api.drive_input_batch(instance, input_id, input_batch, &status, &output);
+                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
 
                 ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
                 result.warning_count += status.warning_count;
@@ -935,7 +870,7 @@ public:
 
         TiforthBatchViewV2 build_end_output{};
         build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(build_end_output, result.rows);
@@ -945,18 +880,18 @@ public:
 
         TiforthBatchViewV2 probe_end_output{};
         probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        api.drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         result.warning_count += status.warning_count;
         appendJoinOutputRows(probe_end_output, result.rows);
         drain_output();
 
-        api.finish(instance, &status);
+        tiforth_execution_host_v2_finish(instance, &status);
         ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
         ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
 
-        api.release_instance(instance);
-        api.release_executable(executable);
+        tiforth_execution_host_v2_release_instance(instance);
+        tiforth_execution_host_v2_release_executable(executable);
 
         result.rows = canonicalizeRows(std::move(result.rows));
     }
@@ -964,8 +899,6 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
-
     auto donor_serial = runDonorNativeInnerJoin(1);
     auto donor_parallel = runDonorNativeInnerJoin(2);
 
@@ -973,9 +906,9 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
     AdapterRunResult adapter_serial;
-    runAdapterInnerJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    runAdapterInnerJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
     AdapterRunResult adapter_parallel;
-    runAdapterInnerJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    runAdapterInnerJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
@@ -991,8 +924,6 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
-
     auto donor_serial = runDonorNativeBuildOuterJoin(1);
     auto donor_parallel = runDonorNativeBuildOuterJoin(2);
 
@@ -1000,9 +931,9 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
     AdapterRunResult adapter_serial;
-    runAdapterBuildOuterJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    runAdapterBuildOuterJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
     AdapterRunResult adapter_parallel;
-    runAdapterBuildOuterJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    runAdapterBuildOuterJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
@@ -1018,8 +949,6 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
-    auto api = linkedExecutionHostV2Api();
-
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
     auto donor_parallel = runDonorNativeProbeOuterJoin(2);
 
@@ -1027,9 +956,9 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
     ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
 
     AdapterRunResult adapter_serial;
-    runAdapterProbeOuterJoin(api, 1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    runAdapterProbeOuterJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
     AdapterRunResult adapter_parallel;
-    runAdapterProbeOuterJoin(api, 2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+    runAdapterProbeOuterJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -14,6 +14,7 @@
 
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsNumber.h>
+#include <Functions/TiforthExecutionHostV2Adapter.h>
 #include <Functions/FunctionHelpers.h>
 #include <TestUtils/ExecutorTestUtils.h>
 #include <gtest/gtest.h>
@@ -35,7 +36,6 @@ namespace
 {
 
 constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
-constexpr uint32_t PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD = 2;
 constexpr uint32_t PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 6;
 constexpr uint32_t PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 10;
 constexpr uint32_t INPUT_ID_BUILD = 0;
@@ -47,10 +47,6 @@ constexpr uint32_t PHYSICAL_TYPE_INT64 = 1;
 constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
 constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
 constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_CHARSET = 1u << 2;
-constexpr uint32_t AMBIENT_REQUIREMENT_DEFAULT_COLLATION = 1u << 3;
-constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
-constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
 constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
 
 class ScopedRuntimeDylibEnvOverride
@@ -784,120 +780,24 @@ public:
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask =
-            AMBIENT_REQUIREMENT_CHARSET | AMBIENT_REQUIREMENT_DEFAULT_COLLATION;
-        build_request.sql_mode = 0;
-        build_request.session_charset = SESSION_CHARSET_UTF8MB4;
-        build_request.default_collation = DEFAULT_COLLATION_UTF8MB4_BIN;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = max_block_size;
+        String load_error;
+        auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+        ASSERT_TRUE(maybe_api.has_value()) << load_error;
 
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        auto run_result = Tiforth::runJoinUtf8KeyInt64Payload(
+            maybe_api.value(),
+            Tiforth::PLAN_KIND_INNER_HASH_JOIN_UTF8_KEY_INT64_PAYLOAD,
+            build_rows,
+            probe_rows,
+            partitions,
+            ownership_mode,
+            Tiforth::AMBIENT_REQUIREMENT_CHARSET | Tiforth::AMBIENT_REQUIREMENT_DEFAULT_COLLATION,
+            Tiforth::SESSION_CHARSET_UTF8MB4,
+            Tiforth::DEFAULT_COLLATION_UTF8MB4_BIN,
+            max_block_size);
 
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        tiforth_execution_host_v2_build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        tiforth_execution_host_v2_open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-        std::vector<JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        {
-            retained_batches.reserve(
-                partitionedChunkCount(build_rows.size(), partitions)
-                + partitionedChunkCount(probe_rows.size(), partitions));
-        }
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        tiforth_execution_host_v2_finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        tiforth_execution_host_v2_release_instance(instance);
-        tiforth_execution_host_v2_release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
+        result.rows = std::move(run_result.rows);
+        result.warning_count = run_result.warning_count;
     }
 
     void runAdapterInnerJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -244,6 +244,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "build_outer_empty_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("build_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
@@ -262,6 +269,13 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 2, {}, 5}),
              toNullableVec<Int64>("probe_payload", {100, 200, 300, 500})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_empty_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("probe_payload", std::vector<std::optional<Int64>>{})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -484,6 +498,14 @@ public:
             "build_outer_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinEmptyBuild(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_probe_input",
+            "build_outer_empty_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -542,6 +564,14 @@ public:
             concurrency,
             "probe_outer_probe_input",
             "probe_outer_empty_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinEmptyProbe(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_empty_probe_input",
+            "probe_outer_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -649,6 +679,11 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> emptyBuildOuterBuildRows()
+    {
+        return {};
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterProbeRows()
     {
         return {
@@ -749,6 +784,11 @@ public:
             {std::nullopt, 300},
             {5, 500},
         };
+    }
+
+    static std::vector<Int64JoinInputRow> emptyProbeOuterProbeRows()
+    {
+        return {};
     }
 
     static std::vector<Int64JoinInputRow> fanoutProbeOuterBuildRows()
@@ -1708,6 +1748,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadEmptyBuildParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinEmptyBuild(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinEmptyBuild(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1997,6 +2075,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), defaultProbeOuterProbeRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadEmptyProbeParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinEmptyProbe(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinEmptyProbe(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultProbeOuterBuildRows(),
+        emptyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultProbeOuterBuildRows(),
+        emptyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1074,6 +1074,42 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityHighPa
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeInnerJoin(1);
+    auto donor_parallel = runDonorNativeInnerJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)
 {
     auto donor_serial = runDonorNativeBuildOuterJoin(1);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -482,6 +482,8 @@ public:
         const std::vector<JoinInputRow> & build_rows,
         const std::vector<JoinInputRow> & probe_rows,
         uint32_t max_block_size,
+        bool build_end_with_output,
+        bool probe_end_with_output,
         AdapterRunResult & result)
     {
         String load_error;
@@ -498,10 +500,31 @@ public:
             Tiforth::AMBIENT_REQUIREMENT_CHARSET | Tiforth::AMBIENT_REQUIREMENT_DEFAULT_COLLATION,
             Tiforth::SESSION_CHARSET_UTF8MB4,
             Tiforth::DEFAULT_COLLATION_UTF8MB4_BIN,
-            max_block_size);
+            max_block_size,
+            build_end_with_output,
+            probe_end_with_output);
 
         result.rows = std::move(run_result.rows);
         result.warning_count = run_result.warning_count;
+    }
+
+    void runAdapterInnerJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        const std::vector<JoinInputRow> & build_rows,
+        const std::vector<JoinInputRow> & probe_rows,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        runAdapterInnerJoin(
+            partitions,
+            ownership_mode,
+            build_rows,
+            probe_rows,
+            max_block_size,
+            true,
+            true,
+            result);
     }
 
     void runAdapterInnerJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
@@ -512,6 +535,8 @@ public:
             defaultInnerJoinBuildRows(),
             defaultInnerJoinProbeRows(),
             0,
+            true,
+            true,
             result);
     }
 
@@ -841,6 +866,43 @@ TEST_F(
         fanoutInnerJoinBuildRows(),
         fanoutInnerJoinProbeRows(),
         1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinFanout(1);
+    auto donor_parallel = runDonorNativeInnerJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        false,
+        false,
         adapter_parallel);
 
     ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -188,6 +188,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "empty_inner_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", std::vector<std::optional<String>>{}),
+             toNullableVec<Int64>("probe_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "fanout_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
@@ -409,6 +416,14 @@ public:
             "empty_inner_build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinEmptyProbe(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "empty_inner_probe_input",
+            "build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -615,6 +630,11 @@ public:
     }
 
     static std::vector<JoinInputRow> emptyInnerJoinBuildRows()
+    {
+        return {};
+    }
+
+    static std::vector<JoinInputRow> emptyInnerJoinProbeRows()
     {
         return {};
     }
@@ -1331,6 +1351,44 @@ TEST_F(
         BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
         emptyInnerJoinBuildRows(),
         defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadEmptyProbeParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinEmptyProbe(1);
+    auto donor_parallel = runDonorNativeInnerJoinEmptyProbe(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        emptyInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        emptyInnerJoinProbeRows(),
         1,
         false,
         false,

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -209,6 +209,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_probe_only_inner_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("probe_payload", {110, 111, 112})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "fanout_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
@@ -279,6 +286,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_probe_only_build_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("probe_payload", {110, 111, 112})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
@@ -318,6 +332,13 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {{}, {}, {}}),
              toNullableVec<Int64>("probe_payload", {100, 101, 102})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_probe_only_probe_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("probe_payload", {110, 111, 112})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -496,6 +517,14 @@ public:
             "all_null_inner_build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinAllNullProbeOnly(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "all_null_probe_only_inner_probe_input",
+            "build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -580,6 +609,14 @@ public:
             "all_null_build_outer_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinAllNullProbeOnly(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "all_null_probe_only_build_outer_probe_input",
+            "build_outer_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -662,6 +699,14 @@ public:
             concurrency,
             "all_null_probe_outer_probe_input",
             "all_null_probe_outer_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinAllNullProbeOnly(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "all_null_probe_only_probe_outer_probe_input",
+            "probe_outer_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -777,6 +822,15 @@ public:
         };
     }
 
+    static std::vector<JoinInputRow> allNullProbeOnlyInnerProbeRows()
+    {
+        return {
+            {std::nullopt, 110},
+            {std::nullopt, 111},
+            {std::nullopt, 112},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
     {
         return {
@@ -887,6 +941,15 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> allNullProbeOnlyBuildOuterProbeRows()
+    {
+        return {
+            {std::nullopt, 110},
+            {std::nullopt, 111},
+            {std::nullopt, 112},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultProbeOuterBuildRows()
     {
         return {
@@ -993,6 +1056,15 @@ public:
             {std::nullopt, 100},
             {std::nullopt, 101},
             {std::nullopt, 102},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> allNullProbeOnlyProbeOuterProbeRows()
+    {
+        return {
+            {std::nullopt, 110},
+            {std::nullopt, 111},
+            {std::nullopt, 112},
         };
     }
 
@@ -1661,6 +1733,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeInnerJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        allNullProbeOnlyInnerProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        allNullProbeOnlyInnerProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2080,6 +2190,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultBuildOuterBuildRows(),
+        allNullProbeOnlyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultBuildOuterBuildRows(),
+        allNullProbeOnlyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2483,6 +2631,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), allNullProbeOuterProbeRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultProbeOuterBuildRows(),
+        allNullProbeOnlyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultProbeOuterBuildRows(),
+        allNullProbeOnlyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullProbeOnlyProbeOuterProbeRows().size());
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1099,6 +1099,28 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeBuildOuterJoin(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoin(2);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)
 {
     auto donor_serial = runDonorNativeBuildOuterJoin(1);
@@ -1147,6 +1169,28 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
               << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeProbeOuterJoin(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoin(2);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
 }
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -174,6 +174,14 @@ std::vector<JoinOutputRow> canonicalizeRows(std::vector<JoinOutputRow> rows)
     return rows;
 }
 
+size_t partitionedChunkCount(size_t row_count, size_t partitions)
+{
+    if (row_count == 0)
+        return 0;
+    const size_t chunk_size = std::max<size_t>(1, (row_count + partitions - 1) / partitions);
+    return (row_count + chunk_size - 1) / chunk_size;
+}
+
 struct JoinBatchOwned
 {
     std::vector<uint8_t> key_null_bitmap;
@@ -581,7 +589,11 @@ public:
         result.warning_count = 0;
         std::vector<JoinBatchOwned> retained_batches;
         if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
+        {
+            retained_batches.reserve(
+                partitionedChunkCount(build_rows.size(), partitions)
+                + partitionedChunkCount(probe_rows.size(), partitions));
+        }
 
         auto drain_output = [&]() {
             while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
@@ -671,7 +683,11 @@ public:
             result);
     }
 
-    void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
+    void runAdapterBuildOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
     {
         TiforthExecutionBuildRequestV2 build_request{};
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -684,7 +700,7 @@ public:
         build_request.decimal_precision = 0;
         build_request.decimal_scale_is_set = false;
         build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
+        build_request.max_block_size = max_block_size;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -703,9 +719,24 @@ public:
 
         result.rows.clear();
         result.warning_count = 0;
+        const std::vector<Int64JoinInputRow> build_rows = {
+            {1, 10},
+            {1, 11},
+            {5, 50},
+            {7, 70},
+        };
+        const std::vector<Int64JoinInputRow> probe_rows = {
+            {1, 100},
+            {5, 500},
+        };
+
         std::vector<Int64JoinBatchOwned> retained_batches;
         if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
+        {
+            retained_batches.reserve(
+                partitionedChunkCount(build_rows.size(), partitions)
+                + partitionedChunkCount(probe_rows.size(), partitions));
+        }
 
         auto drain_output = [&]() {
             while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
@@ -754,15 +785,142 @@ public:
             }
         };
 
+        drive_input_rows(build_rows, INPUT_ID_BUILD);
+
+        TiforthBatchViewV2 build_end_output{};
+        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
+        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(build_end_output, result.rows);
+        drain_output();
+
+        drive_input_rows(probe_rows, INPUT_ID_PROBE);
+
+        TiforthBatchViewV2 probe_end_output{};
+        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
+        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        result.warning_count += status.warning_count;
+        appendJoinOutputRows(probe_end_output, result.rows);
+        drain_output();
+
+        tiforth_execution_host_v2_finish(instance, &status);
+        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
+
+        tiforth_execution_host_v2_release_instance(instance);
+        tiforth_execution_host_v2_release_executable(executable);
+
+        result.rows = canonicalizeRows(std::move(result.rows));
+    }
+
+    void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
+    {
+        runAdapterBuildOuterJoin(partitions, ownership_mode, 0, result);
+    }
+
+    void runAdapterProbeOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        TiforthExecutionBuildRequestV2 build_request{};
+        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+        build_request.plan_kind = PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
+        build_request.ambient_requirement_mask = 0;
+        build_request.sql_mode = 0;
+        build_request.session_charset = 0;
+        build_request.default_collation = 0;
+        build_request.decimal_precision_is_set = false;
+        build_request.decimal_precision = 0;
+        build_request.decimal_scale_is_set = false;
+        build_request.decimal_scale = 0;
+        build_request.max_block_size = max_block_size;
+
+        TiforthStatusV2 status{};
+        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+
+        TiforthExecutionExecutableHandleV2 * executable = nullptr;
+        tiforth_execution_host_v2_build(&build_request, &status, &executable);
+        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
+        ASSERT_NE(executable, nullptr);
+
+        TiforthExecutionInstanceHandleV2 * instance = nullptr;
+        tiforth_execution_host_v2_open(executable, &status, &instance);
+        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
+        ASSERT_NE(instance, nullptr);
+
+        result.rows.clear();
+        result.warning_count = 0;
         const std::vector<Int64JoinInputRow> build_rows = {
             {1, 10},
             {1, 11},
             {5, 50},
-            {7, 70},
         };
         const std::vector<Int64JoinInputRow> probe_rows = {
             {1, 100},
+            {2, 200},
+            {std::nullopt, 300},
             {5, 500},
+        };
+
+        std::vector<Int64JoinBatchOwned> retained_batches;
+        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+        {
+            retained_batches.reserve(
+                partitionedChunkCount(build_rows.size(), partitions)
+                + partitionedChunkCount(probe_rows.size(), partitions));
+        }
+
+        auto drain_output = [&]() {
+            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
+            {
+                TiforthBatchViewV2 continued_output{};
+                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
+
+                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+                result.warning_count += status.warning_count;
+                appendJoinOutputRows(continued_output, result.rows);
+            }
+            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
+        };
+
+        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
+            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
+            for (size_t start = 0; start < rows.size(); start += chunk_size)
+            {
+                const size_t end = std::min(rows.size(), start + chunk_size);
+                std::vector<Int64JoinInputRow> chunk(
+                    rows.begin() + static_cast<ptrdiff_t>(start),
+                    rows.begin() + static_cast<ptrdiff_t>(end));
+
+                const TiforthBatchViewV2 * input_batch = nullptr;
+                std::optional<Int64JoinBatchOwned> borrowed_batch;
+                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
+                {
+                    retained_batches.emplace_back(chunk, ownership_mode);
+                    input_batch = &retained_batches.back().batch;
+                }
+                else
+                {
+                    borrowed_batch.emplace(chunk, ownership_mode);
+                    input_batch = &borrowed_batch->batch;
+                }
+
+                TiforthBatchViewV2 output{};
+                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
+                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
+
+                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
+                result.warning_count += status.warning_count;
+                appendJoinOutputRows(output, result.rows);
+                drain_output();
+            }
         };
 
         drive_input_rows(build_rows, INPUT_ID_BUILD);
@@ -797,127 +955,7 @@ public:
 
     void runAdapterProbeOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask = 0;
-        build_request.sql_mode = 0;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        tiforth_execution_host_v2_build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        tiforth_execution_host_v2_open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-        std::vector<Int64JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-            retained_batches.reserve(8);
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<Int64JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<Int64JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        const std::vector<Int64JoinInputRow> build_rows = {
-            {1, 10},
-            {1, 11},
-            {5, 50},
-        };
-        const std::vector<Int64JoinInputRow> probe_rows = {
-            {1, 100},
-            {2, 200},
-            {std::nullopt, 300},
-            {5, 500},
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        tiforth_execution_host_v2_finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        tiforth_execution_host_v2_release_instance(instance);
-        tiforth_execution_host_v2_release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
+        runAdapterProbeOuterJoin(partitions, ownership_mode, 0, result);
     }
 };
 
@@ -1008,6 +1046,31 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoin(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(8, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, 1, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(8, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, 1, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-build-outer-join-high-partition] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
@@ -1031,6 +1094,31 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
               << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoin(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(8, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, 1, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(8, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, 1, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-probe-outer-join-high-partition] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
 }
 
 } // namespace

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstddef>
 #include <cstdint>
 #include <fmt/core.h>
@@ -50,6 +51,36 @@ constexpr uint32_t AMBIENT_REQUIREMENT_CHARSET = 1u << 2;
 constexpr uint32_t AMBIENT_REQUIREMENT_DEFAULT_COLLATION = 1u << 3;
 constexpr uint32_t SESSION_CHARSET_UTF8MB4 = 1;
 constexpr uint32_t DEFAULT_COLLATION_UTF8MB4_BIN = 1;
+constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
+
+class ScopedRuntimeDylibEnvOverride
+{
+public:
+    explicit ScopedRuntimeDylibEnvOverride(const char * value)
+    {
+        if (const char * current = std::getenv("TIFORTH_FFI_C_DYLIB"); current != nullptr)
+        {
+            had_previous_value = true;
+            previous_value = current;
+        }
+        applied = (::setenv("TIFORTH_FFI_C_DYLIB", value, 1) == 0);
+    }
+
+    ~ScopedRuntimeDylibEnvOverride()
+    {
+        if (had_previous_value)
+            (void)::setenv("TIFORTH_FFI_C_DYLIB", previous_value.c_str(), 1);
+        else
+            (void)::unsetenv("TIFORTH_FFI_C_DYLIB");
+    }
+
+    bool ok() const { return applied; }
+
+private:
+    bool had_previous_value = false;
+    bool applied = false;
+    String previous_value;
+};
 
 struct TiforthExecutionBuildRequestV2
 {
@@ -982,6 +1013,28 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
               << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeInnerJoin(1);
+    auto donor_parallel = runDonorNativeInnerJoin(2);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(1, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(2, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
 }
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -481,6 +481,20 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "fanout_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 12, 20, 30, 40})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "fanout_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"k", "k", "x", "y", {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 200, 300, 400})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "build_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5, 7}),
@@ -508,12 +522,15 @@ public:
              toNullableVec<Int64>("probe_payload", {100, 200, 300, 500})});
     }
 
-    DonorRunResult runDonorNativeInnerJoin(size_t concurrency)
+    DonorRunResult runDonorNativeInnerJoinWithInputs(
+        size_t concurrency,
+        const char * probe_table,
+        const char * build_table)
     {
         getDAGContext().clearWarnings();
-        auto request = context.scan("tiforth_host_v2", "probe_input")
+        auto request = context.scan("tiforth_host_v2", probe_table)
                            .join(
-                               context.scan("tiforth_host_v2", "build_input"),
+                               context.scan("tiforth_host_v2", build_table),
                                tipb::JoinType::TypeInnerJoin,
                                {col("join_key")})
                            .project({"build_payload", "probe_payload"})
@@ -523,6 +540,16 @@ public:
         result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
         result.warning_count = getDAGContext().getWarningCount();
         return result;
+    }
+
+    DonorRunResult runDonorNativeInnerJoin(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(concurrency, "probe_input", "build_input");
+    }
+
+    DonorRunResult runDonorNativeInnerJoinFanout(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(concurrency, "fanout_probe_input", "fanout_build_input");
     }
 
     DonorRunResult runDonorNativeBuildOuterJoin(size_t concurrency)
@@ -575,6 +602,29 @@ public:
             {String("k"), 100},
             {String("x"), 200},
             {String("z"), 300},
+            {std::nullopt, 400},
+        };
+    }
+
+    static std::vector<JoinInputRow> fanoutInnerJoinBuildRows()
+    {
+        return {
+            {String("k"), 10},
+            {String("k"), 11},
+            {String("k"), 12},
+            {String("x"), 20},
+            {String("z"), 30},
+            {std::nullopt, 40},
+        };
+    }
+
+    static std::vector<JoinInputRow> fanoutInnerJoinProbeRows()
+    {
+        return {
+            {String("k"), 100},
+            {String("k"), 101},
+            {String("x"), 200},
+            {String("y"), 300},
             {std::nullopt, 400},
         };
     }
@@ -1069,6 +1119,44 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityHighPa
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
 
     std::cout << "[tiforth-host-v2-inner-join-high-partition] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinFanout(1);
+    auto donor_parallel = runDonorNativeInnerJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 7u);
+
+    std::cout << "[tiforth-host-v2-inner-join-fanout] serial=8 warnings=" << adapter_serial.warning_count
               << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -171,7 +171,7 @@ void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2
 }
 
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
-#error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
+#error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
 #endif
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -195,6 +195,20 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "null_fanout_inner_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"k", "k", "x", "x", {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 20, 21, 30})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "null_fanout_inner_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"k", "k", "x", {}, "y"}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 200, 300, 400})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "build_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5, 7}),
@@ -320,6 +334,14 @@ public:
     DonorRunResult runDonorNativeInnerJoinFanout(size_t concurrency)
     {
         return runDonorNativeInnerJoinWithInputs(concurrency, "fanout_probe_input", "fanout_build_input");
+    }
+
+    DonorRunResult runDonorNativeInnerJoinNullFanout(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "null_fanout_inner_probe_input",
+            "null_fanout_inner_build_input");
     }
 
     DonorRunResult runDonorNativeInnerJoinDisjoint(size_t concurrency)
@@ -458,6 +480,28 @@ public:
             {String("x"), 200},
             {String("y"), 300},
             {std::nullopt, 400},
+        };
+    }
+
+    static std::vector<JoinInputRow> nullFanoutInnerJoinBuildRows()
+    {
+        return {
+            {String("k"), 10},
+            {String("k"), 11},
+            {String("x"), 20},
+            {String("x"), 21},
+            {std::nullopt, 30},
+        };
+    }
+
+    static std::vector<JoinInputRow> nullFanoutInnerJoinProbeRows()
+    {
+        return {
+            {String("k"), 100},
+            {String("k"), 101},
+            {String("x"), 200},
+            {std::nullopt, 300},
+            {String("y"), 400},
         };
     }
 
@@ -1035,6 +1079,44 @@ TEST_F(
     ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadNullFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinNullFanout(1);
+    auto donor_parallel = runDonorNativeInnerJoinNullFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        nullFanoutInnerJoinBuildRows(),
+        nullFanoutInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        nullFanoutInnerJoinBuildRows(),
+        nullFanoutInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 6u);
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -757,6 +757,42 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadFanoutParity
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeInnerJoinFanout(1);
+    auto donor_parallel = runDonorNativeInnerJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutInnerJoinBuildRows(),
+        fanoutInnerJoinProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -265,6 +265,34 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "build_outer_null_fanout_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, {}, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 20, 30, 31})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "build_outer_null_fanout_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, {}, 8}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 200, 300, 800})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_null_fanout_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, {}, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 20, 30, 31})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_null_fanout_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, {}, 9}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 200, 300, 900})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "disjoint_inner_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"a", "b", "c", {}}),
@@ -388,6 +416,14 @@ public:
             "build_outer_fanout_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinNullFanout(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_null_fanout_probe_input",
+            "build_outer_null_fanout_build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinDisjoint(size_t concurrency)
     {
         return runDonorNativeBuildOuterJoinWithInputs(
@@ -430,6 +466,14 @@ public:
             concurrency,
             "probe_outer_fanout_probe_input",
             "probe_outer_fanout_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinNullFanout(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_null_fanout_probe_input",
+            "probe_outer_null_fanout_build_input");
     }
 
     DonorRunResult runDonorNativeProbeOuterJoinDisjoint(size_t concurrency)
@@ -566,6 +610,28 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> nullFanoutBuildOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {2, 20},
+            {std::nullopt, 30},
+            {std::nullopt, 31},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> nullFanoutBuildOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {1, 101},
+            {2, 200},
+            {std::nullopt, 300},
+            {8, 800},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> disjointBuildOuterBuildRows()
     {
         return {
@@ -623,6 +689,28 @@ public:
             {1, 102},
             {3, 300},
             {std::nullopt, 999},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> nullFanoutProbeOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {2, 20},
+            {std::nullopt, 30},
+            {std::nullopt, 31},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> nullFanoutProbeOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {1, 101},
+            {2, 200},
+            {std::nullopt, 300},
+            {9, 900},
         };
     }
 
@@ -1388,6 +1476,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadNullFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinNullFanout(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinNullFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        nullFanoutBuildOuterBuildRows(),
+        nullFanoutBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        nullFanoutBuildOuterBuildRows(),
+        nullFanoutBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 7u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1601,6 +1727,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), 4u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadNullFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinNullFanout(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinNullFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        nullFanoutProbeOuterBuildRows(),
+        nullFanoutProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        nullFanoutProbeOuterBuildRows(),
+        nullFanoutProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 7u);
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -520,6 +520,34 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 2, {}, 5}),
              toNullableVec<Int64>("probe_payload", {100, 200, 300, 500})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "build_outer_fanout_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 1, 2, 7, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 12, 20, 70, 90})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "build_outer_fanout_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, 8, {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 200, 800, 900})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_fanout_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 2, {}}),
+             toNullableVec<Int64>("build_payload", {10, 11, 20, 90})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_fanout_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 1, 1, 3, {}}),
+             toNullableVec<Int64>("probe_payload", {100, 101, 102, 300, 999})});
     }
 
     DonorRunResult runDonorNativeInnerJoinWithInputs(
@@ -552,13 +580,52 @@ public:
         return runDonorNativeInnerJoinWithInputs(concurrency, "fanout_probe_input", "fanout_build_input");
     }
 
-    DonorRunResult runDonorNativeBuildOuterJoin(size_t concurrency)
+    DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
+        size_t concurrency,
+        const char * probe_table,
+        const char * build_table)
     {
         getDAGContext().clearWarnings();
-        auto request = context.scan("tiforth_host_v2", "build_outer_probe_input")
+        auto request = context.scan("tiforth_host_v2", probe_table)
                            .join(
-                               context.scan("tiforth_host_v2", "build_outer_build_input"),
+                               context.scan("tiforth_host_v2", build_table),
                                tipb::JoinType::TypeRightOuterJoin,
+                               {col("join_key")})
+                           .project({"build_payload", "probe_payload"})
+                           .build(context);
+
+        DonorRunResult result;
+        result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
+        result.warning_count = getDAGContext().getWarningCount();
+        return result;
+    }
+
+    DonorRunResult runDonorNativeBuildOuterJoin(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_probe_input",
+            "build_outer_build_input");
+    }
+
+    DonorRunResult runDonorNativeBuildOuterJoinFanout(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_fanout_probe_input",
+            "build_outer_fanout_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
+        size_t concurrency,
+        const char * probe_table,
+        const char * build_table)
+    {
+        getDAGContext().clearWarnings();
+        auto request = context.scan("tiforth_host_v2", probe_table)
+                           .join(
+                               context.scan("tiforth_host_v2", build_table),
+                               tipb::JoinType::TypeLeftOuterJoin,
                                {col("join_key")})
                            .project({"build_payload", "probe_payload"})
                            .build(context);
@@ -571,19 +638,18 @@ public:
 
     DonorRunResult runDonorNativeProbeOuterJoin(size_t concurrency)
     {
-        getDAGContext().clearWarnings();
-        auto request = context.scan("tiforth_host_v2", "probe_outer_probe_input")
-                           .join(
-                               context.scan("tiforth_host_v2", "probe_outer_build_input"),
-                               tipb::JoinType::TypeLeftOuterJoin,
-                               {col("join_key")})
-                           .project({"build_payload", "probe_payload"})
-                           .build(context);
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_probe_input",
+            "probe_outer_build_input");
+    }
 
-        DonorRunResult result;
-        result.rows = canonicalizeRows(joinRowsFromColumns(executeStreams(request, concurrency)));
-        result.warning_count = getDAGContext().getWarningCount();
-        return result;
+    DonorRunResult runDonorNativeProbeOuterJoinFanout(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_fanout_probe_input",
+            "probe_outer_fanout_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -626,6 +692,87 @@ public:
             {String("x"), 200},
             {String("y"), 300},
             {std::nullopt, 400},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {5, 50},
+            {7, 70},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> defaultBuildOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {5, 500},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> fanoutBuildOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {1, 12},
+            {2, 20},
+            {7, 70},
+            {std::nullopt, 90},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> fanoutBuildOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {1, 101},
+            {2, 200},
+            {8, 800},
+            {std::nullopt, 900},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> defaultProbeOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {5, 50},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> defaultProbeOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {2, 200},
+            {std::nullopt, 300},
+            {5, 500},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> fanoutProbeOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {1, 11},
+            {2, 20},
+            {std::nullopt, 90},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> fanoutProbeOuterProbeRows()
+    {
+        return {
+            {1, 100},
+            {1, 101},
+            {1, 102},
+            {3, 300},
+            {std::nullopt, 999},
         };
     }
 
@@ -767,6 +914,8 @@ public:
     void runAdapterBuildOuterJoin(
         size_t partitions,
         uint32_t ownership_mode,
+        const std::vector<Int64JoinInputRow> & build_rows,
+        const std::vector<Int64JoinInputRow> & probe_rows,
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
@@ -800,16 +949,6 @@ public:
 
         result.rows.clear();
         result.warning_count = 0;
-        const std::vector<Int64JoinInputRow> build_rows = {
-            {1, 10},
-            {1, 11},
-            {5, 50},
-            {7, 70},
-        };
-        const std::vector<Int64JoinInputRow> probe_rows = {
-            {1, 100},
-            {5, 500},
-        };
 
         std::vector<Int64JoinBatchOwned> retained_batches;
         if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
@@ -898,12 +1037,35 @@ public:
 
     void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
-        runAdapterBuildOuterJoin(partitions, ownership_mode, 0, result);
+        runAdapterBuildOuterJoin(
+            partitions,
+            ownership_mode,
+            defaultBuildOuterBuildRows(),
+            defaultBuildOuterProbeRows(),
+            0,
+            result);
+    }
+
+    void runAdapterBuildOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        runAdapterBuildOuterJoin(
+            partitions,
+            ownership_mode,
+            defaultBuildOuterBuildRows(),
+            defaultBuildOuterProbeRows(),
+            max_block_size,
+            result);
     }
 
     void runAdapterProbeOuterJoin(
         size_t partitions,
         uint32_t ownership_mode,
+        const std::vector<Int64JoinInputRow> & build_rows,
+        const std::vector<Int64JoinInputRow> & probe_rows,
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
@@ -937,17 +1099,6 @@ public:
 
         result.rows.clear();
         result.warning_count = 0;
-        const std::vector<Int64JoinInputRow> build_rows = {
-            {1, 10},
-            {1, 11},
-            {5, 50},
-        };
-        const std::vector<Int64JoinInputRow> probe_rows = {
-            {1, 100},
-            {2, 200},
-            {std::nullopt, 300},
-            {5, 500},
-        };
 
         std::vector<Int64JoinBatchOwned> retained_batches;
         if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
@@ -1036,7 +1187,28 @@ public:
 
     void runAdapterProbeOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
     {
-        runAdapterProbeOuterJoin(partitions, ownership_mode, 0, result);
+        runAdapterProbeOuterJoin(
+            partitions,
+            ownership_mode,
+            defaultProbeOuterBuildRows(),
+            defaultProbeOuterProbeRows(),
+            0,
+            result);
+    }
+
+    void runAdapterProbeOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        runAdapterProbeOuterJoin(
+            partitions,
+            ownership_mode,
+            defaultProbeOuterBuildRows(),
+            defaultProbeOuterProbeRows(),
+            max_block_size,
+            result);
     }
 };
 
@@ -1272,6 +1444,45 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityH
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadFanoutParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinFanout(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutBuildOuterBuildRows(),
+        fanoutBuildOuterProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutBuildOuterBuildRows(),
+        fanoutBuildOuterProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 9u);
+
+    std::cout << "[tiforth-host-v2-build-outer-join-fanout] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1361,6 +1572,45 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityH
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
 
     std::cout << "[tiforth-host-v2-probe-outer-join-high-partition] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadFanoutParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinFanout(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutProbeOuterBuildRows(),
+        fanoutProbeOuterProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutProbeOuterBuildRows(),
+        fanoutProbeOuterProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 8u);
+
+    std::cout << "[tiforth-host-v2-probe-outer-join-fanout] serial=8 warnings=" << adapter_serial.warning_count
               << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -248,6 +248,48 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 1, 3, {}}),
              toNullableVec<Int64>("probe_payload", {100, 101, 102, 300, 999})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_inner_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"a", "b", "c", {}}),
+             toNullableVec<Int64>("build_payload", {10, 20, 30, 40})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_inner_probe_input",
+            {{"join_key", TiDB::TP::TypeString}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {"x", "y", "z", {}}),
+             toNullableVec<Int64>("probe_payload", {100, 200, 300, 400})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_build_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 2, 3, {}}),
+             toNullableVec<Int64>("build_payload", {10, 20, 30, 40})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_build_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {7, 8, 9, {}}),
+             toNullableVec<Int64>("probe_payload", {700, 800, 900, 1000})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_probe_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {1, 2, 3, {}}),
+             toNullableVec<Int64>("build_payload", {10, 20, 30, 40})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "disjoint_probe_outer_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {7, 8, 9, {}}),
+             toNullableVec<Int64>("probe_payload", {700, 800, 900, 1000})});
     }
 
     DonorRunResult runDonorNativeInnerJoinWithInputs(
@@ -278,6 +320,14 @@ public:
     DonorRunResult runDonorNativeInnerJoinFanout(size_t concurrency)
     {
         return runDonorNativeInnerJoinWithInputs(concurrency, "fanout_probe_input", "fanout_build_input");
+    }
+
+    DonorRunResult runDonorNativeInnerJoinDisjoint(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "disjoint_inner_probe_input",
+            "disjoint_inner_build_input");
     }
 
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
@@ -316,6 +366,14 @@ public:
             "build_outer_fanout_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinDisjoint(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "disjoint_build_outer_probe_input",
+            "disjoint_build_outer_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -350,6 +408,14 @@ public:
             concurrency,
             "probe_outer_fanout_probe_input",
             "probe_outer_fanout_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinDisjoint(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "disjoint_probe_outer_probe_input",
+            "disjoint_probe_outer_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -395,6 +461,26 @@ public:
         };
     }
 
+    static std::vector<JoinInputRow> disjointInnerJoinBuildRows()
+    {
+        return {
+            {String("a"), 10},
+            {String("b"), 20},
+            {String("c"), 30},
+            {std::nullopt, 40},
+        };
+    }
+
+    static std::vector<JoinInputRow> disjointInnerJoinProbeRows()
+    {
+        return {
+            {String("x"), 100},
+            {String("y"), 200},
+            {String("z"), 300},
+            {std::nullopt, 400},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
     {
         return {
@@ -436,6 +522,26 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> disjointBuildOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {2, 20},
+            {3, 30},
+            {std::nullopt, 40},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> disjointBuildOuterProbeRows()
+    {
+        return {
+            {7, 700},
+            {8, 800},
+            {9, 900},
+            {std::nullopt, 1000},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultProbeOuterBuildRows()
     {
         return {
@@ -473,6 +579,26 @@ public:
             {1, 102},
             {3, 300},
             {std::nullopt, 999},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> disjointProbeOuterBuildRows()
+    {
+        return {
+            {1, 10},
+            {2, 20},
+            {3, 30},
+            {std::nullopt, 40},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> disjointProbeOuterProbeRows()
+    {
+        return {
+            {7, 700},
+            {8, 800},
+            {9, 900},
+            {std::nullopt, 1000},
         };
     }
 
@@ -913,6 +1039,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadDisjointParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinDisjoint(1);
+    auto donor_parallel = runDonorNativeInnerJoinDisjoint(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        disjointInnerJoinBuildRows(),
+        disjointInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        disjointInnerJoinBuildRows(),
+        disjointInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1104,6 +1268,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadDisjointParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinDisjoint(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinDisjoint(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        disjointBuildOuterBuildRows(),
+        disjointBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        disjointBuildOuterBuildRows(),
+        disjointBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 4u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1279,6 +1481,44 @@ TEST_F(
               << adapter_parallel.warning_count << " rows=" << adapter_parallel.rows.size()
               << " donor_warnings=" << donor_serial.warning_count << " donor_rows=" << donor_serial.rows.size()
               << " max_block_size=1 end_with_output=0 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadDisjointParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinDisjoint(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinDisjoint(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        disjointProbeOuterBuildRows(),
+        disjointProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        disjointProbeOuterBuildRows(),
+        disjointProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 4u);
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -520,7 +520,33 @@ public:
         return result;
     }
 
-    void runAdapterInnerJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
+    static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
+    {
+        return {
+            {String("k"), 10},
+            {String("k"), 20},
+            {String("x"), 30},
+            {std::nullopt, 40},
+        };
+    }
+
+    static std::vector<JoinInputRow> defaultInnerJoinProbeRows()
+    {
+        return {
+            {String("k"), 100},
+            {String("x"), 200},
+            {String("z"), 300},
+            {std::nullopt, 400},
+        };
+    }
+
+    void runAdapterInnerJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        const std::vector<JoinInputRow> & build_rows,
+        const std::vector<JoinInputRow> & probe_rows,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
     {
         TiforthExecutionBuildRequestV2 build_request{};
         build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -534,7 +560,7 @@ public:
         build_request.decimal_precision = 0;
         build_request.decimal_scale_is_set = false;
         build_request.decimal_scale = 0;
-        build_request.max_block_size = 0;
+        build_request.max_block_size = max_block_size;
 
         TiforthStatusV2 status{};
         status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
@@ -604,19 +630,6 @@ public:
             }
         };
 
-        const std::vector<JoinInputRow> build_rows = {
-            {String("k"), 10},
-            {String("k"), 20},
-            {String("x"), 30},
-            {std::nullopt, 40},
-        };
-        const std::vector<JoinInputRow> probe_rows = {
-            {String("k"), 100},
-            {String("x"), 200},
-            {String("z"), 300},
-            {std::nullopt, 400},
-        };
-
         drive_input_rows(build_rows, INPUT_ID_BUILD);
 
         TiforthBatchViewV2 build_end_output{};
@@ -645,6 +658,17 @@ public:
         tiforth_execution_host_v2_release_executable(executable);
 
         result.rows = canonicalizeRows(std::move(result.rows));
+    }
+
+    void runAdapterInnerJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
+    {
+        runAdapterInnerJoin(
+            partitions,
+            ownership_mode,
+            defaultInnerJoinBuildRows(),
+            defaultInnerJoinProbeRows(),
+            0,
+            result);
     }
 
     void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
@@ -920,6 +944,43 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
               << " rows=" << adapter_serial.rows.size() << " parallel=2 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
+}
+
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoin(1);
+    auto donor_parallel = runDonorNativeInnerJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+
+    std::cout << "[tiforth-host-v2-inner-join-high-partition] serial=8 warnings=" << adapter_serial.warning_count
+              << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
+              << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
+              << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
 }
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1182,6 +1182,30 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityH
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeBuildOuterJoin(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(8, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, 1, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(8, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, 1, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+}
+
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
@@ -1252,6 +1276,30 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityH
               << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeProbeOuterJoin(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoin(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(8, BATCH_OWNERSHIP_BORROW_WITHIN_CALL, 1, adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(8, BATCH_OWNERSHIP_FOREIGN_RETAINABLE, 1, adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
 }
 
 } // namespace

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -35,16 +35,6 @@ namespace DB::tests
 namespace
 {
 
-constexpr uint32_t EXECUTION_HOST_V2_ABI_VERSION = 4;
-constexpr uint32_t PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 6;
-constexpr uint32_t PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD = 10;
-constexpr uint32_t INPUT_ID_BUILD = 0;
-constexpr uint32_t INPUT_ID_PROBE = 1;
-constexpr uint32_t STATUS_KIND_OK = 0;
-constexpr uint32_t STATUS_CODE_NONE = 0;
-constexpr uint32_t STATUS_CODE_MORE_OUTPUT_AVAILABLE = 29;
-constexpr uint32_t PHYSICAL_TYPE_INT64 = 1;
-constexpr uint32_t PHYSICAL_TYPE_UTF8 = 2;
 constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
 constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
 constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
@@ -78,105 +68,9 @@ private:
     String previous_value;
 };
 
-struct TiforthExecutionBuildRequestV2
-{
-    uint32_t abi_version;
-    uint32_t plan_kind;
-    uint32_t ambient_requirement_mask;
-    uint32_t sql_mode;
-    uint32_t session_charset;
-    uint32_t default_collation;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-    uint32_t max_block_size;
-};
-
-struct TiforthExecutionColumnViewV2
-{
-    uint32_t physical_type;
-    const uint8_t * null_bitmap;
-    uint32_t null_bitmap_bit_offset;
-    uint32_t row_offset;
-    const int64_t * values;
-    const int32_t * offsets;
-    const uint8_t * data;
-    const void * decimal128_words;
-    bool decimal_precision_is_set;
-    uint8_t decimal_precision;
-    bool decimal_scale_is_set;
-    int8_t decimal_scale;
-};
-
-struct TiforthBatchViewV2
-{
-    uint32_t abi_version;
-    uint32_t ownership_mode;
-    uint32_t column_count;
-    uint32_t row_count;
-    const TiforthExecutionColumnViewV2 * columns;
-};
-
-struct TiforthStatusV2
-{
-    uint32_t abi_version;
-    uint32_t kind;
-    uint32_t code;
-    uint32_t warning_count;
-    char message[256];
-};
-
-struct TiforthExecutionExecutableHandleV2;
-struct TiforthExecutionInstanceHandleV2;
-
-extern "C"
-{
-void tiforth_execution_host_v2_build(
-    const TiforthExecutionBuildRequestV2 * request,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionExecutableHandleV2 ** out_executable);
-void tiforth_execution_host_v2_open(
-    const TiforthExecutionExecutableHandleV2 * executable,
-    TiforthStatusV2 * out_status,
-    TiforthExecutionInstanceHandleV2 ** out_instance);
-void tiforth_execution_host_v2_drive_input_batch(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    const TiforthBatchViewV2 * input,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_drive_end_of_input(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_drive_end_of_input_with_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    uint32_t input_id,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_continue_output(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status,
-    TiforthBatchViewV2 * out_output);
-void tiforth_execution_host_v2_finish(
-    TiforthExecutionInstanceHandleV2 * instance,
-    TiforthStatusV2 * out_status);
-void tiforth_execution_host_v2_release_executable(TiforthExecutionExecutableHandleV2 * executable);
-void tiforth_execution_host_v2_release_instance(TiforthExecutionInstanceHandleV2 * instance);
-}
-
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
 #error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
 #endif
-
-bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
-{
-    if (column.null_bitmap == nullptr || row_count == 0)
-        return true;
-    const size_t bit_index = static_cast<size_t>(column.null_bitmap_bit_offset) + row;
-    return (column.null_bitmap[bit_index / 8] & (1u << (bit_index % 8))) != 0;
-}
 
 using JoinInputRow = std::pair<std::optional<String>, std::optional<int64_t>>;
 using Int64JoinInputRow = std::pair<std::optional<int64_t>, std::optional<int64_t>>;
@@ -199,196 +93,6 @@ std::vector<JoinOutputRow> canonicalizeRows(std::vector<JoinOutputRow> rows)
             return rank_value(lhs.second) < rank_value(rhs.second);
         });
     return rows;
-}
-
-size_t partitionedChunkCount(size_t row_count, size_t partitions)
-{
-    if (row_count == 0)
-        return 0;
-    const size_t chunk_size = std::max<size_t>(1, (row_count + partitions - 1) / partitions);
-    return (row_count + chunk_size - 1) / chunk_size;
-}
-
-struct JoinBatchOwned
-{
-    std::vector<uint8_t> key_null_bitmap;
-    std::vector<int32_t> key_offsets;
-    String key_data;
-
-    std::vector<int64_t> payload_values;
-    std::vector<uint8_t> payload_null_bitmap;
-
-    TiforthExecutionColumnViewV2 columns[2]{};
-    TiforthBatchViewV2 batch{};
-
-    JoinBatchOwned(const std::vector<JoinInputRow> & rows, uint32_t ownership_mode)
-    {
-        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-        key_offsets.reserve(rows.size() + 1);
-        key_offsets.push_back(0);
-
-        payload_values.reserve(rows.size());
-        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].first.has_value())
-            {
-                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                key_data.append(rows[i].first.value());
-            }
-            key_offsets.push_back(static_cast<int32_t>(key_data.size()));
-
-            if (rows[i].second.has_value())
-            {
-                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                payload_values.push_back(rows[i].second.value());
-            }
-            else
-            {
-                payload_values.push_back(0);
-            }
-        }
-
-        columns[0].physical_type = PHYSICAL_TYPE_UTF8;
-        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
-        columns[0].null_bitmap_bit_offset = 0;
-        columns[0].row_offset = 0;
-        columns[0].values = nullptr;
-        columns[0].offsets = key_offsets.data();
-        columns[0].data = key_data.empty() ? nullptr : reinterpret_cast<const uint8_t *>(key_data.data());
-        columns[0].decimal128_words = nullptr;
-        columns[0].decimal_precision_is_set = false;
-        columns[0].decimal_precision = 0;
-        columns[0].decimal_scale_is_set = false;
-        columns[0].decimal_scale = 0;
-
-        columns[1].physical_type = PHYSICAL_TYPE_INT64;
-        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
-        columns[1].null_bitmap_bit_offset = 0;
-        columns[1].row_offset = 0;
-        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
-        columns[1].offsets = nullptr;
-        columns[1].data = nullptr;
-        columns[1].decimal128_words = nullptr;
-        columns[1].decimal_precision_is_set = false;
-        columns[1].decimal_precision = 0;
-        columns[1].decimal_scale_is_set = false;
-        columns[1].decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 2;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = columns;
-    }
-};
-
-struct Int64JoinBatchOwned
-{
-    std::vector<int64_t> key_values;
-    std::vector<uint8_t> key_null_bitmap;
-
-    std::vector<int64_t> payload_values;
-    std::vector<uint8_t> payload_null_bitmap;
-
-    TiforthExecutionColumnViewV2 columns[2]{};
-    TiforthBatchViewV2 batch{};
-
-    Int64JoinBatchOwned(const std::vector<Int64JoinInputRow> & rows, uint32_t ownership_mode)
-    {
-        key_values.reserve(rows.size());
-        key_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        payload_values.reserve(rows.size());
-        payload_null_bitmap.assign(rows.empty() ? 0 : (rows.size() + 7) / 8, 0);
-
-        for (size_t i = 0; i < rows.size(); ++i)
-        {
-            if (rows[i].first.has_value())
-            {
-                key_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                key_values.push_back(rows[i].first.value());
-            }
-            else
-            {
-                key_values.push_back(0);
-            }
-
-            if (rows[i].second.has_value())
-            {
-                payload_null_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
-                payload_values.push_back(rows[i].second.value());
-            }
-            else
-            {
-                payload_values.push_back(0);
-            }
-        }
-
-        columns[0].physical_type = PHYSICAL_TYPE_INT64;
-        columns[0].null_bitmap = key_null_bitmap.empty() ? nullptr : key_null_bitmap.data();
-        columns[0].null_bitmap_bit_offset = 0;
-        columns[0].row_offset = 0;
-        columns[0].values = key_values.empty() ? nullptr : key_values.data();
-        columns[0].offsets = nullptr;
-        columns[0].data = nullptr;
-        columns[0].decimal128_words = nullptr;
-        columns[0].decimal_precision_is_set = false;
-        columns[0].decimal_precision = 0;
-        columns[0].decimal_scale_is_set = false;
-        columns[0].decimal_scale = 0;
-
-        columns[1].physical_type = PHYSICAL_TYPE_INT64;
-        columns[1].null_bitmap = payload_null_bitmap.empty() ? nullptr : payload_null_bitmap.data();
-        columns[1].null_bitmap_bit_offset = 0;
-        columns[1].row_offset = 0;
-        columns[1].values = payload_values.empty() ? nullptr : payload_values.data();
-        columns[1].offsets = nullptr;
-        columns[1].data = nullptr;
-        columns[1].decimal128_words = nullptr;
-        columns[1].decimal_precision_is_set = false;
-        columns[1].decimal_precision = 0;
-        columns[1].decimal_scale_is_set = false;
-        columns[1].decimal_scale = 0;
-
-        batch.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        batch.ownership_mode = ownership_mode;
-        batch.column_count = 2;
-        batch.row_count = static_cast<uint32_t>(rows.size());
-        batch.columns = columns;
-    }
-};
-
-void appendJoinOutputRows(const TiforthBatchViewV2 & output, std::vector<JoinOutputRow> & rows)
-{
-    if (output.row_count == 0)
-        return;
-
-    ASSERT_EQ(output.column_count, 2u);
-
-    const auto & build_payload = output.columns[0];
-    const auto & probe_payload = output.columns[1];
-
-    ASSERT_EQ(build_payload.physical_type, PHYSICAL_TYPE_INT64);
-    ASSERT_EQ(probe_payload.physical_type, PHYSICAL_TYPE_INT64);
-
-    ASSERT_NE(build_payload.values, nullptr);
-    ASSERT_NE(probe_payload.values, nullptr);
-
-    const auto * build_values = build_payload.values + build_payload.row_offset;
-    const auto * probe_values = probe_payload.values + probe_payload.row_offset;
-
-    for (size_t row = 0; row < output.row_count; ++row)
-    {
-        const auto build_value = isValidRow(build_payload, output.row_count, row)
-            ? std::optional<int64_t>(build_values[row])
-            : std::nullopt;
-        const auto probe_value = isValidRow(probe_payload, output.row_count, row)
-            ? std::optional<int64_t>(probe_values[row])
-            : std::nullopt;
-        rows.emplace_back(build_value, probe_value);
-    }
 }
 
 std::vector<std::optional<int64_t>> readNullableInt64Column(const ColumnWithTypeAndName & column)
@@ -811,6 +515,35 @@ public:
             result);
     }
 
+    void runAdapterInt64Join(
+        uint32_t plan_kind,
+        size_t partitions,
+        uint32_t ownership_mode,
+        const std::vector<Int64JoinInputRow> & build_rows,
+        const std::vector<Int64JoinInputRow> & probe_rows,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        String load_error;
+        auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+        ASSERT_TRUE(maybe_api.has_value()) << load_error;
+
+        auto run_result = Tiforth::runJoinInt64KeyInt64Payload(
+            maybe_api.value(),
+            plan_kind,
+            build_rows,
+            probe_rows,
+            partitions,
+            ownership_mode,
+            0,
+            0,
+            0,
+            max_block_size);
+
+        result.rows = std::move(run_result.rows);
+        result.warning_count = run_result.warning_count;
+    }
+
     void runAdapterBuildOuterJoin(
         size_t partitions,
         uint32_t ownership_mode,
@@ -819,120 +552,14 @@ public:
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask = 0;
-        build_request.sql_mode = 0;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = max_block_size;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        tiforth_execution_host_v2_build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        tiforth_execution_host_v2_open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-
-        std::vector<Int64JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        {
-            retained_batches.reserve(
-                partitionedChunkCount(build_rows.size(), partitions)
-                + partitionedChunkCount(probe_rows.size(), partitions));
-        }
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<Int64JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<Int64JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        tiforth_execution_host_v2_finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        tiforth_execution_host_v2_release_instance(instance);
-        tiforth_execution_host_v2_release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
+        runAdapterInt64Join(
+            Tiforth::PLAN_KIND_BUILD_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+            partitions,
+            ownership_mode,
+            build_rows,
+            probe_rows,
+            max_block_size,
+            result);
     }
 
     void runAdapterBuildOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)
@@ -969,120 +596,14 @@ public:
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
-        TiforthExecutionBuildRequestV2 build_request{};
-        build_request.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        build_request.plan_kind = PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD;
-        build_request.ambient_requirement_mask = 0;
-        build_request.sql_mode = 0;
-        build_request.session_charset = 0;
-        build_request.default_collation = 0;
-        build_request.decimal_precision_is_set = false;
-        build_request.decimal_precision = 0;
-        build_request.decimal_scale_is_set = false;
-        build_request.decimal_scale = 0;
-        build_request.max_block_size = max_block_size;
-
-        TiforthStatusV2 status{};
-        status.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-
-        TiforthExecutionExecutableHandleV2 * executable = nullptr;
-        tiforth_execution_host_v2_build(&build_request, &status, &executable);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(executable, nullptr);
-
-        TiforthExecutionInstanceHandleV2 * instance = nullptr;
-        tiforth_execution_host_v2_open(executable, &status, &instance);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        ASSERT_NE(instance, nullptr);
-
-        result.rows.clear();
-        result.warning_count = 0;
-
-        std::vector<Int64JoinBatchOwned> retained_batches;
-        if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-        {
-            retained_batches.reserve(
-                partitionedChunkCount(build_rows.size(), partitions)
-                + partitionedChunkCount(probe_rows.size(), partitions));
-        }
-
-        auto drain_output = [&]() {
-            while (status.code == STATUS_CODE_MORE_OUTPUT_AVAILABLE)
-            {
-                TiforthBatchViewV2 continued_output{};
-                continued_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_continue_output(instance, &status, &continued_output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(continued_output, result.rows);
-            }
-            ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-        };
-
-        auto drive_input_rows = [&](const std::vector<Int64JoinInputRow> & rows, uint32_t input_id) {
-            const size_t chunk_size = std::max<size_t>(1, (rows.size() + partitions - 1) / partitions);
-            for (size_t start = 0; start < rows.size(); start += chunk_size)
-            {
-                const size_t end = std::min(rows.size(), start + chunk_size);
-                std::vector<Int64JoinInputRow> chunk(
-                    rows.begin() + static_cast<ptrdiff_t>(start),
-                    rows.begin() + static_cast<ptrdiff_t>(end));
-
-                const TiforthBatchViewV2 * input_batch = nullptr;
-                std::optional<Int64JoinBatchOwned> borrowed_batch;
-                if (ownership_mode == BATCH_OWNERSHIP_FOREIGN_RETAINABLE)
-                {
-                    retained_batches.emplace_back(chunk, ownership_mode);
-                    input_batch = &retained_batches.back().batch;
-                }
-                else
-                {
-                    borrowed_batch.emplace(chunk, ownership_mode);
-                    input_batch = &borrowed_batch->batch;
-                }
-
-                TiforthBatchViewV2 output{};
-                output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-                tiforth_execution_host_v2_drive_input_batch(instance, input_id, input_batch, &status, &output);
-
-                ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-                result.warning_count += status.warning_count;
-                appendJoinOutputRows(output, result.rows);
-                drain_output();
-            }
-        };
-
-        drive_input_rows(build_rows, INPUT_ID_BUILD);
-
-        TiforthBatchViewV2 build_end_output{};
-        build_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_BUILD, &status, &build_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(build_end_output, result.rows);
-        drain_output();
-
-        drive_input_rows(probe_rows, INPUT_ID_PROBE);
-
-        TiforthBatchViewV2 probe_end_output{};
-        probe_end_output.abi_version = EXECUTION_HOST_V2_ABI_VERSION;
-        tiforth_execution_host_v2_drive_end_of_input_with_output(instance, INPUT_ID_PROBE, &status, &probe_end_output);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        result.warning_count += status.warning_count;
-        appendJoinOutputRows(probe_end_output, result.rows);
-        drain_output();
-
-        tiforth_execution_host_v2_finish(instance, &status);
-        ASSERT_EQ(status.kind, STATUS_KIND_OK) << status.message;
-        ASSERT_EQ(status.code, STATUS_CODE_NONE) << status.message;
-
-        tiforth_execution_host_v2_release_instance(instance);
-        tiforth_execution_host_v2_release_executable(executable);
-
-        result.rows = canonicalizeRows(std::move(result.rows));
+        runAdapterInt64Join(
+            Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+            partitions,
+            ownership_mode,
+            build_rows,
+            probe_rows,
+            max_block_size,
+            result);
     }
 
     void runAdapterProbeOuterJoin(size_t partitions, uint32_t ownership_mode, AdapterRunResult & result)

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -522,6 +522,8 @@ public:
         const std::vector<Int64JoinInputRow> & build_rows,
         const std::vector<Int64JoinInputRow> & probe_rows,
         uint32_t max_block_size,
+        bool build_end_with_output,
+        bool probe_end_with_output,
         AdapterRunResult & result)
     {
         String load_error;
@@ -538,7 +540,9 @@ public:
             0,
             0,
             0,
-            max_block_size);
+            max_block_size,
+            build_end_with_output,
+            probe_end_with_output);
 
         result.rows = std::move(run_result.rows);
         result.warning_count = run_result.warning_count;
@@ -550,6 +554,8 @@ public:
         const std::vector<Int64JoinInputRow> & build_rows,
         const std::vector<Int64JoinInputRow> & probe_rows,
         uint32_t max_block_size,
+        bool build_end_with_output,
+        bool probe_end_with_output,
         AdapterRunResult & result)
     {
         runAdapterInt64Join(
@@ -559,6 +565,27 @@ public:
             build_rows,
             probe_rows,
             max_block_size,
+            build_end_with_output,
+            probe_end_with_output,
+            result);
+    }
+
+    void runAdapterBuildOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        const std::vector<Int64JoinInputRow> & build_rows,
+        const std::vector<Int64JoinInputRow> & probe_rows,
+        uint32_t max_block_size,
+        AdapterRunResult & result)
+    {
+        runAdapterBuildOuterJoin(
+            partitions,
+            ownership_mode,
+            build_rows,
+            probe_rows,
+            max_block_size,
+            true,
+            true,
             result);
     }
 
@@ -570,6 +597,8 @@ public:
             defaultBuildOuterBuildRows(),
             defaultBuildOuterProbeRows(),
             0,
+            true,
+            true,
             result);
     }
 
@@ -585,6 +614,30 @@ public:
             defaultBuildOuterBuildRows(),
             defaultBuildOuterProbeRows(),
             max_block_size,
+            true,
+            true,
+            result);
+    }
+
+    void runAdapterProbeOuterJoin(
+        size_t partitions,
+        uint32_t ownership_mode,
+        const std::vector<Int64JoinInputRow> & build_rows,
+        const std::vector<Int64JoinInputRow> & probe_rows,
+        uint32_t max_block_size,
+        bool build_end_with_output,
+        bool probe_end_with_output,
+        AdapterRunResult & result)
+    {
+        runAdapterInt64Join(
+            Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+            partitions,
+            ownership_mode,
+            build_rows,
+            probe_rows,
+            max_block_size,
+            build_end_with_output,
+            probe_end_with_output,
             result);
     }
 
@@ -596,13 +649,14 @@ public:
         uint32_t max_block_size,
         AdapterRunResult & result)
     {
-        runAdapterInt64Join(
-            Tiforth::PLAN_KIND_PROBE_OUTER_HASH_JOIN_INT64_KEY_INT64_PAYLOAD,
+        runAdapterProbeOuterJoin(
             partitions,
             ownership_mode,
             build_rows,
             probe_rows,
             max_block_size,
+            true,
+            true,
             result);
     }
 
@@ -614,6 +668,8 @@ public:
             defaultProbeOuterBuildRows(),
             defaultProbeOuterProbeRows(),
             0,
+            true,
+            true,
             result);
     }
 
@@ -629,6 +685,8 @@ public:
             defaultProbeOuterBuildRows(),
             defaultProbeOuterProbeRows(),
             max_block_size,
+            true,
+            true,
             result);
     }
 };
@@ -940,6 +998,50 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinFanout(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutBuildOuterBuildRows(),
+        fanoutBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutBuildOuterBuildRows(),
+        fanoutBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 9u);
+
+    std::cout << "[tiforth-host-v2-build-outer-join-fanout-legacy-end] serial=8 warnings="
+              << adapter_serial.warning_count << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings="
+              << adapter_parallel.warning_count << " rows=" << adapter_parallel.rows.size()
+              << " donor_warnings=" << donor_serial.warning_count << " donor_rows=" << donor_serial.rows.size()
+              << " max_block_size=1 end_with_output=0 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1071,6 +1173,50 @@ TEST_F(
               << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings=" << adapter_parallel.warning_count
               << " rows=" << adapter_parallel.rows.size() << " donor_warnings=" << donor_serial.warning_count
               << " donor_rows=" << donor_serial.rows.size() << " max_block_size=1 parity=ok" << std::endl;
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadFanoutParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinFanout(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinFanout(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        fanoutProbeOuterBuildRows(),
+        fanoutProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        fanoutProbeOuterBuildRows(),
+        fanoutProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 8u);
+
+    std::cout << "[tiforth-host-v2-probe-outer-join-fanout-legacy-end] serial=8 warnings="
+              << adapter_serial.warning_count << " rows=" << adapter_serial.rows.size() << " parallel=8 warnings="
+              << adapter_parallel.warning_count << " rows=" << adapter_parallel.rows.size()
+              << " donor_warnings=" << donor_serial.warning_count << " donor_rows=" << donor_serial.rows.size()
+              << " max_block_size=1 end_with_output=0 parity=ok" << std::endl;
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -216,6 +216,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_build_only_inner_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("build_payload", {120, 121, 122})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "fanout_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
@@ -293,6 +300,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "all_null_build_only_build_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("build_payload", {120, 121, 122})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
@@ -339,6 +353,13 @@ public:
             {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {{}, {}, {}}),
              toNullableVec<Int64>("probe_payload", {110, 111, 112})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "all_null_build_only_probe_outer_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", {{}, {}, {}}),
+             toNullableVec<Int64>("build_payload", {120, 121, 122})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -525,6 +546,14 @@ public:
             "build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinAllNullBuildOnly(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "probe_input",
+            "all_null_build_only_inner_build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -617,6 +646,14 @@ public:
             "build_outer_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinAllNullBuildOnly(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_probe_input",
+            "all_null_build_only_build_outer_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -707,6 +744,14 @@ public:
             concurrency,
             "all_null_probe_only_probe_outer_probe_input",
             "probe_outer_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinAllNullBuildOnly(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_probe_input",
+            "all_null_build_only_probe_outer_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -831,6 +876,15 @@ public:
         };
     }
 
+    static std::vector<JoinInputRow> allNullBuildOnlyInnerBuildRows()
+    {
+        return {
+            {std::nullopt, 120},
+            {std::nullopt, 121},
+            {std::nullopt, 122},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
     {
         return {
@@ -950,6 +1004,15 @@ public:
         };
     }
 
+    static std::vector<Int64JoinInputRow> allNullBuildOnlyBuildOuterBuildRows()
+    {
+        return {
+            {std::nullopt, 120},
+            {std::nullopt, 121},
+            {std::nullopt, 122},
+        };
+    }
+
     static std::vector<Int64JoinInputRow> defaultProbeOuterBuildRows()
     {
         return {
@@ -1065,6 +1128,15 @@ public:
             {std::nullopt, 110},
             {std::nullopt, 111},
             {std::nullopt, 112},
+        };
+    }
+
+    static std::vector<Int64JoinInputRow> allNullBuildOnlyProbeOuterBuildRows()
+    {
+        return {
+            {std::nullopt, 120},
+            {std::nullopt, 121},
+            {std::nullopt, 122},
         };
     }
 
@@ -1771,6 +1843,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeInnerJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyInnerBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyInnerBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2228,6 +2338,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullBuildOnlyBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2669,6 +2817,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), allNullProbeOnlyProbeOuterProbeRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultProbeOuterProbeRows().size());
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -181,6 +181,13 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "empty_inner_build_input",
+            {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<String>("join_key", std::vector<std::optional<String>>{}),
+             toNullableVec<Int64>("build_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "fanout_build_input",
             {{"join_key", TiDB::TP::TypeString}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<String>("join_key", {"k", "k", "k", "x", "z", {}}),
@@ -223,10 +230,24 @@ public:
 
         context.addMockTable(
             "tiforth_host_v2",
+            "build_outer_empty_probe_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"probe_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("probe_payload", std::vector<std::optional<Int64>>{})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
             "probe_outer_build_input",
             {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
             {toNullableVec<Int64>("join_key", {1, 1, 5}),
              toNullableVec<Int64>("build_payload", {10, 11, 50})});
+
+        context.addMockTable(
+            "tiforth_host_v2",
+            "probe_outer_empty_build_input",
+            {{"join_key", TiDB::TP::TypeLongLong}, {"build_payload", TiDB::TP::TypeLongLong}},
+            {toNullableVec<Int64>("join_key", std::vector<std::optional<Int64>>{}),
+             toNullableVec<Int64>("build_payload", std::vector<std::optional<Int64>>{})});
 
         context.addMockTable(
             "tiforth_host_v2",
@@ -380,6 +401,14 @@ public:
             "disjoint_inner_build_input");
     }
 
+    DonorRunResult runDonorNativeInnerJoinEmptyBuild(size_t concurrency)
+    {
+        return runDonorNativeInnerJoinWithInputs(
+            concurrency,
+            "probe_input",
+            "empty_inner_build_input");
+    }
+
     DonorRunResult runDonorNativeBuildOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -432,6 +461,14 @@ public:
             "disjoint_build_outer_build_input");
     }
 
+    DonorRunResult runDonorNativeBuildOuterJoinEmptyProbe(size_t concurrency)
+    {
+        return runDonorNativeBuildOuterJoinWithInputs(
+            concurrency,
+            "build_outer_empty_probe_input",
+            "build_outer_build_input");
+    }
+
     DonorRunResult runDonorNativeProbeOuterJoinWithInputs(
         size_t concurrency,
         const char * probe_table,
@@ -482,6 +519,14 @@ public:
             concurrency,
             "disjoint_probe_outer_probe_input",
             "disjoint_probe_outer_build_input");
+    }
+
+    DonorRunResult runDonorNativeProbeOuterJoinEmptyBuild(size_t concurrency)
+    {
+        return runDonorNativeProbeOuterJoinWithInputs(
+            concurrency,
+            "probe_outer_probe_input",
+            "probe_outer_empty_build_input");
     }
 
     static std::vector<JoinInputRow> defaultInnerJoinBuildRows()
@@ -569,6 +614,11 @@ public:
         };
     }
 
+    static std::vector<JoinInputRow> emptyInnerJoinBuildRows()
+    {
+        return {};
+    }
+
     static std::vector<Int64JoinInputRow> defaultBuildOuterBuildRows()
     {
         return {
@@ -585,6 +635,11 @@ public:
             {1, 100},
             {5, 500},
         };
+    }
+
+    static std::vector<Int64JoinInputRow> emptyBuildOuterProbeRows()
+    {
+        return {};
     }
 
     static std::vector<Int64JoinInputRow> fanoutBuildOuterBuildRows()
@@ -659,6 +714,11 @@ public:
             {1, 11},
             {5, 50},
         };
+    }
+
+    static std::vector<Int64JoinInputRow> emptyProbeOuterBuildRows()
+    {
+        return {};
     }
 
     static std::vector<Int64JoinInputRow> defaultProbeOuterProbeRows()
@@ -1247,6 +1307,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadEmptyBuildParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeInnerJoinEmptyBuild(1);
+    auto donor_parallel = runDonorNativeInnerJoinEmptyBuild(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyInnerJoinBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1514,6 +1612,44 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadEmptyProbeParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeBuildOuterJoinEmptyProbe(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinEmptyProbe(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultBuildOuterBuildRows(),
+        emptyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultBuildOuterBuildRows(),
+        emptyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -1765,6 +1901,44 @@ TEST_F(
     ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
     ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
     ASSERT_EQ(adapter_serial.rows.size(), 7u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadEmptyBuildParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
+{
+    auto donor_serial = runDonorNativeProbeOuterJoinEmptyBuild(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinEmptyBuild(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        emptyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        emptyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultProbeOuterProbeRows().size());
 }
 
 TEST_F(

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -21,7 +21,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <fmt/core.h>
 #include <iostream>
 #include <optional>
@@ -178,10 +177,12 @@ struct TiforthExecutionHostV2Api
     ReleaseInstanceFn release_instance = nullptr;
 };
 
-std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
+#if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
+#error "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
+#endif
+
+TiforthExecutionHostV2Api linkedExecutionHostV2Api()
 {
-#if defined(TIFORTH_HOST_V2_LINKED_TESTS)
-    (void)error;
     TiforthExecutionHostV2Api api;
     api.build = tiforth_execution_host_v2_build;
     api.open = tiforth_execution_host_v2_open;
@@ -193,22 +194,6 @@ std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
     api.release_executable = tiforth_execution_host_v2_release_executable;
     api.release_instance = tiforth_execution_host_v2_release_instance;
     return api;
-#else
-    error
-        = "build gtests_dbms with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON "
-          "and either -DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> "
-          "or -DTIFORTH_FFI_C_LIB_DIR=/abs/path/to/libdir "
-          "(-DTIFORTH_FFI_C_LIB_NAME defaults to tiforth_ffi_c); "
-          "see dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md "
-          "to run this donor adapter test";
-    return std::nullopt;
-#endif
-}
-
-bool requiresStrictRuntimeExecution()
-{
-    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
-    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
 }
 
 bool isValidRow(const TiforthExecutionColumnViewV2 & column, uint32_t row_count, size_t row)
@@ -979,18 +964,7 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
 
     auto donor_serial = runDonorNativeInnerJoin(1);
     auto donor_parallel = runDonorNativeInnerJoin(2);
@@ -1017,18 +991,7 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
 
     auto donor_serial = runDonorNativeBuildOuterJoin(1);
     auto donor_parallel = runDonorNativeBuildOuterJoin(2);
@@ -1055,18 +1018,7 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
 
 TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = requiresStrictRuntimeExecution();
-    String load_error;
-    auto maybe_api = loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
-    auto api = std::move(maybe_api.value());
+    auto api = linkedExecutionHostV2Api();
 
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
     auto donor_parallel = runDonorNativeProbeOuterJoin(2);


### PR DESCRIPTION
Role: Coder-R203

## Summary
- add a focused donor-native cast parity slice for malformed multi-dot input on the linked host-v2 adapter path
- assert donor baseline explicitly (`"1.2.3" -> "0.000"` under truncate-as-warning) before checking adapter serial/parallel parity
- keep this slice on donor test entry -> linked host-v2 path used by Gate D blocker #251

## Why
- open #251 evidence shows strict linked runtime reaches donor gtests but remains blocked on invalid-syntax cast parity (`donor 0.000` vs `adapter 1.200`)
- this PR provides a direct, isolated donor executable slice for that exact mismatch so follow-up core carryover can be validated against a stable donor baseline

## Validation
- not executed in this branch: local linked configure currently fails before test build in this worktree because required donor submodules are not materialized from `tiforth` base (`contrib/protobuf`, `contrib/re2`, etc.)

Refs: zanmato1984/tiforth#251
Refs: zanmato1984/tiforth#77
