### PR TITLE
Role: Coder-R253: extend linked all-null-build-only runtime-dylib-independence parity slices for Gate D #251

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1925,6 +1925,47 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeInnerJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeInnerJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyInnerBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyInnerBuildRows(),
+        defaultInnerJoinProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -2461,6 +2461,47 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeBuildOuterJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyBuildOuterBuildRows(),
+        defaultBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullBuildOnlyBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
@@ -2908,6 +2949,47 @@ TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
     ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
 {
+    auto donor_serial = runDonorNativeProbeOuterJoinAllNullBuildOnly(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinAllNullBuildOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        allNullBuildOnlyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        allNullBuildOnlyProbeOuterBuildRows(),
+        defaultProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultProbeOuterProbeRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
     auto donor_serial = runDonorNativeProbeOuterJoinAllNullBuildOnly(1);
     auto donor_parallel = runDonorNativeProbeOuterJoinAllNullBuildOnly(4);
 


### PR DESCRIPTION
Role: Coder-R253

## Summary
- keep convergence on Gate D blocker `zanmato1984/tiforth#251` in the selected open donor PR
- extend linked host-v2 runtime-dylib-independence parity coverage in `dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp` by forcing bogus `TIFORTH_FFI_C_DYLIB` while requiring donor-vs-adapter parity under both ownership modes (`partitions=8`, `max_block_size=1`, legacy end)
- slices now covered in this PR:
  - `InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel`
  - `BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel`
  - `ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel`

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo build -p tiforth-ffi-c` in `/Users/zanmato/dev/tiforth-worktrees/tiforth-r246-lib-20260411-135502`
- `./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh`
- `cmake -S . -B /tmp/tiflash-r253-issue251-linked-host-v2 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-r246-lib-20260411-135502/target/debug/libtiforth_ffi_c.dylib`
- `cmake --build /tmp/tiflash-r253-issue251-linked-host-v2 --target dbms/CMakeFiles/gtests_tiforth_execution_host_v2.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp.o -j4`
- `ctest --test-dir /tmp/tiflash-r253-issue251-linked-host-v2 -N -R TestTiforthExecutionHostV2LinkedStrict`

Refs zanmato1984/tiforth#251
Refs zanmato1984/tiforth#77
