### PR TITLE
Role: Coder-R254: carry linked signed multi-dot CAST runtime-dylib-independence slice for Gate D #251

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -290,6 +290,51 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
               << std::endl;
 }
 
+TEST_F(
+    TestTiforthExecutionHostV2Cast,
+    CastUtf8ToDecimalMalformedMultiDotZeroParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("1.2.3"),
+        String("bad"),
+        String("12.340"),
+        String("-0.500"),
+        std::nullopt,
+        String(""),
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+}
+
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
 {
     const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -348,6 +348,51 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
 
 TEST_F(
     TestTiforthExecutionHostV2Cast,
+    CastUtf8ToDecimalMalformedSignedMultiDotZeroParityIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
+    String load_error;
+    auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
+    if (!maybe_api.has_value())
+    {
+        if (strict_runtime_execution)
+            GTEST_FAIL() << load_error;
+        SUCCEED() << load_error;
+        return;
+    }
+
+    auto api = std::move(maybe_api.value());
+    auto & dag_context = getDAGContext();
+    ScopedDAGFlags scoped_dag_flags(dag_context);
+    dag_context.addFlag(TiDBSQLFlags::TRUNCATE_AS_WARNING);
+
+    const std::vector<std::optional<String>> input = {
+        String("-1.2.3"),
+        String("+1.2.3"),
+        String("-bad"),
+        String("+"),
+        String("-0.500"),
+        std::nullopt,
+    };
+
+    auto donor_native = runDonorNativeCastAsString(input);
+    const auto donor_warning_count = static_cast<uint32_t>(dag_context.getWarningCount());
+    ASSERT_EQ(donor_warning_count, 0u);
+
+    auto serial = runAdapterCast(api, input, 1, Tiforth::BATCH_OWNERSHIP_BORROW_WITHIN_CALL);
+    auto parallel = runAdapterCast(api, input, 2, Tiforth::BATCH_OWNERSHIP_FOREIGN_RETAINABLE);
+
+    ASSERT_EQ(serial.warning_count, donor_warning_count);
+    ASSERT_EQ(parallel.warning_count, donor_warning_count);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(serial.output), donor_native);
+    ASSERT_COLUMN_EQ(createColumn<Nullable<String>>(parallel.output), donor_native);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2Cast,
     CastUtf8ToDecimalScaleLossWarningParityIgnoresRuntimeDylibEnvSerialAndParallel)
 {
     ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);


### PR DESCRIPTION
Role: Coder-R254

## Summary
- add a direct executable linked host-v2 CAST parity slice for malformed signed multi-dot decimal inputs under forced bogus `TIFORTH_FFI_C_DYLIB`
- keep proving execution on compile/link-time wiring and assert donor-native parity in both serial and parallel ownership modes
- keep scope limited to donor carryover for Gate D blocker convergence

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo build -p tiforth-ffi-c` (in tiforth worktree)
- `./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh`
- `cmake -S . -B /tmp/tiflash-r254-issue251-linked-host-v2 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-issue-251-r254-20260411-192546/target/debug/libtiforth_ffi_c.dylib`
- `cmake --build /tmp/tiflash-r254-issue251-linked-host-v2 --target dbms/CMakeFiles/gtests_tiforth_execution_host_v2.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp.o -j4`
- `ctest --test-dir /tmp/tiflash-r254-issue251-linked-host-v2 -N -R TestTiforthExecutionHostV2LinkedStrict`

## Issue
- Refs zanmato1984/tiforth#251
- Refs zanmato1984/tiforth#77
