### PR TITLE
Role: Coder-R257: carry linked all-null-probe-only runtime-dylib-independence slice for Gate D #251

### DIFF
--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -1887,6 +1887,47 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    InnerHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeInnerJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeInnerJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultInnerJoinBuildRows(),
+        allNullProbeOnlyInnerProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterInnerJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultInnerJoinBuildRows(),
+        allNullProbeOnlyInnerProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), 0u);
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
 {
     auto donor_serial = runDonorNativeInnerJoinAllNullBuildOnly(1);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -2464,6 +2464,47 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
+    BuildOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
+    auto donor_serial = runDonorNativeBuildOuterJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeBuildOuterJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultBuildOuterBuildRows(),
+        allNullProbeOnlyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterBuildOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultBuildOuterBuildRows(),
+        allNullProbeOnlyBuildOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), defaultBuildOuterBuildRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
     BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
 {
     auto donor_serial = runDonorNativeBuildOuterJoinAllNullBuildOnly(1);
@@ -2952,6 +2993,47 @@ TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
     ProbeOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndSerialAndParallel)
 {
+    auto donor_serial = runDonorNativeProbeOuterJoinAllNullProbeOnly(1);
+    auto donor_parallel = runDonorNativeProbeOuterJoinAllNullProbeOnly(4);
+
+    ASSERT_EQ(donor_serial.warning_count, donor_parallel.warning_count);
+    ASSERT_EQ(donor_serial.rows, donor_parallel.rows);
+
+    AdapterRunResult adapter_serial;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_BORROW_WITHIN_CALL,
+        defaultProbeOuterBuildRows(),
+        allNullProbeOnlyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_serial);
+    AdapterRunResult adapter_parallel;
+    runAdapterProbeOuterJoin(
+        8,
+        BATCH_OWNERSHIP_FOREIGN_RETAINABLE,
+        defaultProbeOuterBuildRows(),
+        allNullProbeOnlyProbeOuterProbeRows(),
+        1,
+        false,
+        false,
+        adapter_parallel);
+
+    ASSERT_EQ(adapter_serial.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_parallel.warning_count, donor_serial.warning_count);
+    ASSERT_EQ(adapter_serial.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_parallel.rows, donor_serial.rows);
+    ASSERT_EQ(adapter_serial.rows.size(), allNullProbeOnlyProbeOuterProbeRows().size());
+}
+
+TEST_F(
+    TestTiforthExecutionHostV2InnerHashJoin,
+    ProbeOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+{
+    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
+    ASSERT_TRUE(runtime_dylib_override.ok());
+
     auto donor_serial = runDonorNativeProbeOuterJoinAllNullProbeOnly(1);
     auto donor_parallel = runDonorNativeProbeOuterJoinAllNullProbeOnly(4);
 


### PR DESCRIPTION
Role: Coder-R257

## Summary
- add direct executable linked host-v2 parity slice `InnerHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel` in `gtest_tiforth_execution_host_v2_inner_hash_join.cpp`
- force bogus `TIFORTH_FFI_C_DYLIB` and keep donor-vs-adapter parity under both ownership modes (`partitions=8`, `max_block_size=1`, legacy end flags), so proving path stays compile/link-time and runtime-dylib-independent

## Validation
- `RUSTUP_TOOLCHAIN=stable cargo build -p tiforth-ffi-c` (from tiforth issue worktree)
- `./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh`
- `cmake -S . -B /tmp/tiflash-r257-issue251-linked-host-v2 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-issue-251-r257-20260411-202825/target/debug/libtiforth_ffi_c.dylib`
- `cmake --build /tmp/tiflash-r257-issue251-linked-host-v2 --target dbms/CMakeFiles/gtests_tiforth_execution_host_v2.dir/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp.o -j4`
- `ctest --test-dir /tmp/tiflash-r257-issue251-linked-host-v2 -N -R TestTiforthExecutionHostV2LinkedStrict`

Refs zanmato1984/tiforth#251
Refs zanmato1984/tiforth#77
