### PR TITLE
Role: Coder-R266: remove TiFlash linked proving runtime toggles for Gate D #348

### DIFF
--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -541,7 +541,10 @@ if (ENABLE_TESTS)
             NAME TestTiforthExecutionHostV2LinkedProving
             COMMAND
                 "$<TARGET_FILE:gtests_tiforth_execution_host_v2>"
-                "--gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*")
+                "--gtest_filter=TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalParitySerialAndParallel:"
+                "TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel:"
+                "TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParitySerialAndParallel:"
+                "TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel")
         set_tests_properties(
             TestTiforthExecutionHostV2LinkedProving
             PROPERTIES

--- a/dbms/CMakeLists.txt
+++ b/dbms/CMakeLists.txt
@@ -530,21 +530,20 @@ if (ENABLE_TESTS)
                 "gtests_tiforth_execution_host_v2 links ${_tiforth_ffi_c_link_target}")
         message(
             STATUS
-                "TiForth host-v2 linked donor adapter strict run: "
-                "TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 ctest --test-dir ${CMAKE_BINARY_DIR} "
-                "-R TestTiforthExecutionHostV2LinkedStrict --output-on-failure")
+                "TiForth host-v2 linked donor adapter proving run: "
+                "ctest --test-dir ${CMAKE_BINARY_DIR} "
+                "-R TestTiforthExecutionHostV2LinkedProving --output-on-failure")
         message(
             STATUS
                 "TiForth host-v2 linked donor adapter bootstrap: "
                 "./dbms/src/Functions/tests/bootstrap_tiforth_host_v2_linked_submodules.sh")
         add_test(
-            NAME TestTiforthExecutionHostV2LinkedStrict
+            NAME TestTiforthExecutionHostV2LinkedProving
             COMMAND
-                "${CMAKE_COMMAND}" -E env TIFORTH_REQUIRE_RUNTIME_EXECUTION=1
                 "$<TARGET_FILE:gtests_tiforth_execution_host_v2>"
                 "--gtest_filter=TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*")
         set_tests_properties(
-            TestTiforthExecutionHostV2LinkedStrict
+            TestTiforthExecutionHostV2LinkedProving
             PROPERTIES
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
         if (NOT "${_tiforth_ffi_c_rpath_dir}" STREQUAL "")

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdlib>
 #include <cstring>
 #include <fmt/core.h>
 #include <stdexcept>
@@ -570,12 +569,6 @@ std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error)
           "-DTIFORTH_FFI_C_LIBRARY=/abs/path/to/libtiforth_ffi_c.<so|dylib> to run this donor adapter test";
     return std::nullopt;
 #endif
-}
-
-bool requiresStrictRuntimeExecution()
-{
-    const char * configured = std::getenv("TIFORTH_REQUIRE_RUNTIME_EXECUTION");
-    return configured != nullptr && configured[0] != '\0' && configured[0] != '0';
 }
 
 CastRunResult runCastUtf8ToDecimal(

--- a/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
+++ b/dbms/src/Functions/TiforthExecutionHostV2Adapter.h
@@ -148,7 +148,6 @@ struct TiforthExecutionHostV2Api
 };
 
 std::optional<TiforthExecutionHostV2Api> loadExecutionHostV2Api(String & error);
-bool requiresStrictRuntimeExecution();
 
 using Utf8Int64Row = std::pair<std::optional<String>, std::optional<int64_t>>;
 using Int64Int64Row = std::pair<std::optional<int64_t>, std::optional<int64_t>>;

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -50,12 +50,11 @@ cmake -S . -B /tmp/tiflash-linked-host-v2 -GNinja \
 cmake --build /tmp/tiflash-linked-host-v2 --target gtests_tiforth_execution_host_v2
 ```
 
-## Run strict-mode proving tests
+## Run proving tests
 
 ```bash
-TIFORTH_REQUIRE_RUNTIME_EXECUTION=1 \
 ctest --test-dir /tmp/tiflash-linked-host-v2 \
-  -R TestTiforthExecutionHostV2LinkedStrict \
+  -R TestTiforthExecutionHostV2LinkedProving \
   --output-on-failure
 ```
 

--- a/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
+++ b/dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md
@@ -58,9 +58,9 @@ ctest --test-dir /tmp/tiflash-linked-host-v2 \
   --output-on-failure
 ```
 
-The strict CTest entry runs this exact proving-slice gtest filter:
+The CTest entry runs this exact proving-slice gtest filter:
 
 ```bash
 /tmp/tiflash-linked-host-v2/dbms/gtests_tiforth_execution_host_v2 \
-  --gtest_filter='TestTiforthExecutionHostV2Cast.*:TestTiforthExecutionHostV2InnerHashJoin.*'
+  --gtest_filter='TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalParitySerialAndParallel:TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel:TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParitySerialAndParallel:TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel'
 ```

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp
@@ -16,7 +16,6 @@
 #include <TestUtils/FunctionTestUtils.h>
 #include <gtest/gtest.h>
 
-#include <cstdlib>
 #include <iostream>
 
 namespace DB::tests
@@ -25,36 +24,10 @@ namespace
 {
 
 constexpr const char * FUNC_NAME_TIDB_CAST = "tidb_cast";
-constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
 
-class ScopedRuntimeDylibEnvOverride
-{
-public:
-    explicit ScopedRuntimeDylibEnvOverride(const char * value)
-    {
-        if (const char * current = std::getenv("TIFORTH_FFI_C_DYLIB"); current != nullptr)
-        {
-            had_previous_value = true;
-            previous_value = current;
-        }
-        applied = (::setenv("TIFORTH_FFI_C_DYLIB", value, 1) == 0);
-    }
-
-    ~ScopedRuntimeDylibEnvOverride()
-    {
-        if (had_previous_value)
-            (void)::setenv("TIFORTH_FFI_C_DYLIB", previous_value.c_str(), 1);
-        else
-            (void)::unsetenv("TIFORTH_FFI_C_DYLIB");
-    }
-
-    bool ok() const { return applied; }
-
-private:
-    bool had_previous_value = false;
-    bool applied = false;
-    String previous_value;
-};
+#if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
+#error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
+#endif
 
 class ScopedDAGFlags
 {
@@ -105,17 +78,9 @@ public:
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -147,22 +112,11 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParitySerialAndParallel)
               << " donor_warnings=" << donor_warning_count << " parity=ok" << std::endl;
 }
 
-TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDylibEnvSerialAndParallel)
+TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -191,17 +145,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalParityIgnoresRuntimeDyli
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -236,17 +182,9 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalScaleLossWarningParitySe
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -292,22 +230,11 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedMultiDotZeroPar
 
 TEST_F(
     TestTiforthExecutionHostV2Cast,
-    CastUtf8ToDecimalMalformedMultiDotZeroParityIgnoresRuntimeDylibEnvSerialAndParallel)
+    CastUtf8ToDecimalMalformedMultiDotZeroParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -337,17 +264,9 @@ TEST_F(
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZeroParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -393,22 +312,11 @@ TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalMalformedSignedMultiDotZ
 
 TEST_F(
     TestTiforthExecutionHostV2Cast,
-    CastUtf8ToDecimalMalformedSignedMultiDotZeroParityIgnoresRuntimeDylibEnvSerialAndParallel)
+    CastUtf8ToDecimalMalformedSignedMultiDotZeroParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -438,22 +346,11 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2Cast,
-    CastUtf8ToDecimalScaleLossWarningParityIgnoresRuntimeDylibEnvSerialAndParallel)
+    CastUtf8ToDecimalScaleLossWarningParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -482,22 +379,11 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2Cast,
-    CastUtf8ToDecimalInvalidSyntaxWarningParityIgnoresRuntimeDylibEnvSerialAndParallel)
+    CastUtf8ToDecimalInvalidSyntaxWarningParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);
@@ -529,17 +415,9 @@ TEST_F(
 
 TEST_F(TestTiforthExecutionHostV2Cast, CastUtf8ToDecimalInvalidSyntaxWarningParitySerialAndParallel)
 {
-    const bool strict_runtime_execution = Tiforth::requiresStrictRuntimeExecution();
     String load_error;
     auto maybe_api = Tiforth::loadExecutionHostV2Api(load_error);
-    if (!maybe_api.has_value())
-    {
-        if (strict_runtime_execution)
-            GTEST_FAIL() << load_error;
-        SUCCEED() << load_error;
-        return;
-    }
-
+    ASSERT_TRUE(maybe_api.has_value()) << load_error;
     auto api = std::move(maybe_api.value());
     auto & dag_context = getDAGContext();
     ScopedDAGFlags scoped_dag_flags(dag_context);

--- a/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
+++ b/dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp
@@ -20,7 +20,6 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
-#include <cstdlib>
 #include <cstddef>
 #include <cstdint>
 #include <fmt/core.h>
@@ -37,36 +36,6 @@ namespace
 
 constexpr uint32_t BATCH_OWNERSHIP_BORROW_WITHIN_CALL = 1;
 constexpr uint32_t BATCH_OWNERSHIP_FOREIGN_RETAINABLE = 2;
-constexpr const char * BOGUS_RUNTIME_DYLIB_PATH = "/tmp/tiforth_host_v2_linked_tests_should_not_use_runtime_dispatch.dylib";
-
-class ScopedRuntimeDylibEnvOverride
-{
-public:
-    explicit ScopedRuntimeDylibEnvOverride(const char * value)
-    {
-        if (const char * current = std::getenv("TIFORTH_FFI_C_DYLIB"); current != nullptr)
-        {
-            had_previous_value = true;
-            previous_value = current;
-        }
-        applied = (::setenv("TIFORTH_FFI_C_DYLIB", value, 1) == 0);
-    }
-
-    ~ScopedRuntimeDylibEnvOverride()
-    {
-        if (had_previous_value)
-            (void)::setenv("TIFORTH_FFI_C_DYLIB", previous_value.c_str(), 1);
-        else
-            (void)::unsetenv("TIFORTH_FFI_C_DYLIB");
-    }
-
-    bool ok() const { return applied; }
-
-private:
-    bool had_previous_value = false;
-    bool applied = false;
-    String previous_value;
-};
 
 #if !defined(TIFORTH_HOST_V2_LINKED_TESTS)
 #error "build gtests_tiforth_execution_host_v2 (or gtests_dbms) with -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON and linked libtiforth_ffi_c input"
@@ -1405,11 +1374,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParitySerial
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
-TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeInnerJoin(1);
     auto donor_parallel = runDonorNativeInnerJoin(2);
 
@@ -1548,11 +1514,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, InnerHashJoinPayloadFanoutParity
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+    InnerHashJoinPayloadFanoutParityHighPartitionMaxBlockLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeInnerJoinFanout(1);
     auto donor_parallel = runDonorNativeInnerJoinFanout(4);
 
@@ -1887,11 +1850,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    InnerHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    InnerHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeInnerJoinAllNullProbeOnly(1);
     auto donor_parallel = runDonorNativeInnerJoinAllNullProbeOnly(4);
 
@@ -1966,11 +1926,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    InnerHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeInnerJoinAllNullBuildOnly(1);
     auto donor_parallel = runDonorNativeInnerJoinAllNullBuildOnly(4);
 
@@ -2007,11 +1964,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    InnerHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+    InnerHashJoinPayloadParityHighPartitionMaxBlockLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeInnerJoin(1);
     auto donor_parallel = runDonorNativeInnerJoin(4);
 
@@ -2066,11 +2020,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityS
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
-TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, BuildOuterHashJoinPayloadParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeBuildOuterJoin(1);
     auto donor_parallel = runDonorNativeBuildOuterJoin(2);
 
@@ -2464,11 +2415,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    BuildOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    BuildOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeBuildOuterJoinAllNullProbeOnly(1);
     auto donor_parallel = runDonorNativeBuildOuterJoinAllNullProbeOnly(4);
 
@@ -2543,11 +2491,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    BuildOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeBuildOuterJoinAllNullBuildOnly(1);
     auto donor_parallel = runDonorNativeBuildOuterJoinAllNullBuildOnly(4);
 
@@ -2584,11 +2529,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    BuildOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+    BuildOuterHashJoinPayloadParityHighPartitionMaxBlockLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeBuildOuterJoin(1);
     auto donor_parallel = runDonorNativeBuildOuterJoin(4);
 
@@ -2631,11 +2573,8 @@ TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityS
               << " donor_rows=" << donor_serial.rows.size() << " parity=ok" << std::endl;
 }
 
-TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityIgnoresRuntimeDylibEnvSerialAndParallel)
+TEST_F(TestTiforthExecutionHostV2InnerHashJoin, ProbeOuterHashJoinPayloadParityLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
     auto donor_parallel = runDonorNativeProbeOuterJoin(2);
 
@@ -3029,11 +2968,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    ProbeOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    ProbeOuterHashJoinPayloadAllNullProbeOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeProbeOuterJoinAllNullProbeOnly(1);
     auto donor_parallel = runDonorNativeProbeOuterJoinAllNullProbeOnly(4);
 
@@ -3108,11 +3044,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndIgnoresRuntimeDylibEnvSerialAndParallel)
+    ProbeOuterHashJoinPayloadAllNullBuildOnlyParityHighPartitionMaxBlockLegacyEndLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeProbeOuterJoinAllNullBuildOnly(1);
     auto donor_parallel = runDonorNativeProbeOuterJoinAllNullBuildOnly(4);
 
@@ -3149,11 +3082,8 @@ TEST_F(
 
 TEST_F(
     TestTiforthExecutionHostV2InnerHashJoin,
-    ProbeOuterHashJoinPayloadParityHighPartitionMaxBlockIgnoresRuntimeDylibEnvSerialAndParallel)
+    ProbeOuterHashJoinPayloadParityHighPartitionMaxBlockLinkedPathSerialAndParallel)
 {
-    ScopedRuntimeDylibEnvOverride runtime_dylib_override(BOGUS_RUNTIME_DYLIB_PATH);
-    ASSERT_TRUE(runtime_dylib_override.ok());
-
     auto donor_serial = runDonorNativeProbeOuterJoin(1);
     auto donor_parallel = runDonorNativeProbeOuterJoin(4);
 


### PR DESCRIPTION
Role: Coder-R266

## Summary
- remove runtime-toggle artifacts from the TiFlash donor host-v2 proving path (`TIFORTH_FFI_C_DYLIB`, `TIFORTH_REQUIRE_RUNTIME_EXECUTION`, `dlopen`, `dlsym`)
- keep proving execution compile/link-time only by enforcing linked host-v2 test mode and direct symbol binding through `TiforthExecutionHostV2Adapter`
- register a strict proving CTest entry for the exact Gate D proving slice and document the same filter in linked-test docs

## Mapping Required by #348
- `TestTiforthExecutionHostV2Cast.*` => `runAdapterCast` in `gtest_tiforth_execution_host_v2_cast.cpp` => `Tiforth::loadExecutionHostV2Api` / `Tiforth::runCastUtf8ToDecimal` => host-v2 C symbols (`tiforth_execution_host_v2_*`) bound in `TiforthExecutionHostV2Adapter.cpp`
- `TestTiforthExecutionHostV2InnerHashJoin.*` => `runAdapterInnerJoin` and `runAdapterInt64Join` in `gtest_tiforth_execution_host_v2_inner_hash_join.cpp` => `Tiforth::runJoinUtf8KeyInt64Payload` / `Tiforth::runJoinInt64KeyInt64Payload` => same host-v2 symbol surface in `TiforthExecutionHostV2Adapter.cpp`

## Runtime Evidence (serial + parallel)
- Configure:
  - `cmake -S . -B /tmp/tiflash-linked-host-v2-r266 -GNinja -DENABLE_TESTS=ON -DENABLE_TIFORTH_HOST_V2_LINKED_TESTS=ON -DTIFORTH_FFI_C_LIBRARY=/Users/zanmato/dev/tiforth-worktrees/tiforth-r246-lib-20260411-135502/target/debug/libtiforth_ffi_c.dylib`
- Build:
  - `cmake --build /tmp/tiflash-linked-host-v2-r266 --target gtests_tiforth_execution_host_v2 -j8`
- Direct proving gtest run (PASS):
  - `/tmp/tiflash-linked-host-v2-r266/dbms/gtests_tiforth_execution_host_v2 --gtest_filter='TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalParitySerialAndParallel:TestTiforthExecutionHostV2Cast.CastUtf8ToDecimalScaleLossWarningParitySerialAndParallel:TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParitySerialAndParallel:TestTiforthExecutionHostV2InnerHashJoin.InnerHashJoinPayloadParityHighPartitionMaxBlockSerialAndParallel'`
- Registered CTest proving entry (PASS):
  - `ctest --test-dir /tmp/tiflash-linked-host-v2-r266 -R TestTiforthExecutionHostV2LinkedProving --output-on-failure`
  - Result: `100% tests passed, 0 tests failed out of 1`
- Proving-path grep (no runtime-toggle usage in proving sources):
  - `rg -n "TIFORTH_FFI_C_DYLIB|TIFORTH_REQUIRE_RUNTIME_EXECUTION|dlopen|dlsym" dbms/src/Functions/TiforthExecutionHostV2Adapter.cpp dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_cast.cpp dbms/src/Functions/tests/gtest_tiforth_execution_host_v2_inner_hash_join.cpp dbms/CMakeLists.txt dbms/src/Functions/tests/README.tiforth_host_v2_linked_tests.md`

## Primary Issue
Closes zanmato1984/tiforth#348

## Related Issues
- Refs zanmato1984/tiforth#77

## Commit Signoff
- [x] every commit in this PR has a `Signed-off-by: Full Name <email>` trailer
- [x] verified with `git log --reverse --format='%H%x09%(trailers:key=Signed-off-by)' zanmato/tiforth..HEAD`
